### PR TITLE
Refactor CI pipeline to test all supported platforms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,20 +8,39 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux
+          - windows
+          - macos
+          - web
+        include:
+          - platform: linux
+            os: ubuntu-latest
+          - platform: windows
+            os: windows-latest
+          - platform: macos
+            os: macos-latest
+          - platform: web
+            os: ubuntu-latest
+            dartTestArgs: -p chrome
 
-    container:
-      image: google/dart:latest
+    runs-on: ${{ matrix.os }}
 
     steps:
+      - uses: dart-lang/setup-dart@v1.3
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: pub get
+        run: dart pub get
       - name: Run tests
-        run: pub run test
+        run: dart test --reporter expanded ${{ matrix.dartTestArgs }}
       - name: Generate coverage
-        run: pub run test_cov
+        if: runner.os == 'Linux'
+        run: dart run test_cov
       - name: Send coverage report to codecov
+        if: runner.os == 'Linux'
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/test/_support/setup.dart
+++ b/test/_support/setup.dart
@@ -12,6 +12,9 @@ import 'node.dart';
 import 'person.dart';
 import 'pet.dart';
 
+// copied from https://api.flutter.dev/flutter/foundation/kIsWeb-constant.html
+const _kIsWeb = identical(0, 0.0);
+
 //
 
 late ProviderContainer container;
@@ -78,11 +81,12 @@ void setUpFn() async {
         adapters: adapterGraph,
       );
 
+  const nodesKey = _kIsWeb ? 'node1s' : 'nodes';
   nodeRepository = await container.read(nodesRepositoryProvider).initialize(
     remote: false,
     verbose: false,
     adapters: {
-      'nodes': container.read(nodesRemoteAdapterProvider),
+      nodesKey: container.read(nodesRemoteAdapterProvider),
     },
   );
 

--- a/test/storage_test.dart
+++ b/test/storage_test.dart
@@ -1,3 +1,7 @@
+@OnPlatform({
+  'js': Skip(),
+})
+
 import 'dart:io';
 
 import 'package:flutter_data/flutter_data.dart';


### PR DESCRIPTION
Due to #149 I took a look at your CI and would like to contribute the following improvements with the goal to have all tests run on all supported platforms, which should catch bugs similar to that one and ensures consistency across all platforms.

The first commit refactors the CI pipeline. The following changes have been made:
- Instead of a docker image, VM images are used
- the pipeline is now a matrix pipeline, that runs tests for linux, windows, macos and in the browser (chrome)
- Uses the official setup task for dart (latest stable)
- Modernized usage of the dart commands (e.g. `dart test` instead of `pub test`)
- Coverage is only generated and published for the linux run

The second commit updates the tests to work within the browser. Two changes have been made:
- The local storage hive test is simply skipped for now. However, since hive is supported on the web, it might be a good idea to update the test so it works in the web as well https://pub.dev/packages/universal_io might be of help
- Apparently, `Node` is a reserved type in the browser, which is why the Node type of the repository gets compiled to `Node1` in the web, thus the pluralized path is wrong (`node1s` instead of `nodes`). For now, I simply replaces the adapter key for web tests, however, it might be best to simply rename the type to something like `MyNode` instead.