### PR TITLE
Fix problems with web tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           - linux
           - windows
           - macos
+          - web
         include:
           - platform: linux
             os: ubuntu-latest
@@ -22,6 +23,9 @@ jobs:
             os: windows-latest
           - platform: macos
             os: macos-latest
+          - platform: web
+            os: ubuntu-latest
+            dartTestArgs: -p chrome
 
     runs-on: ${{ matrix.os }}
 

--- a/test/_support/familia.dart
+++ b/test/_support/familia.dart
@@ -5,11 +5,11 @@ import 'house.dart';
 import 'person.dart';
 import 'pet.dart';
 
-part 'family.g.dart';
+part 'familia.g.dart';
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
 @DataRepository([])
-class Family with DataModel<Family> {
+class Familia with DataModel<Familia> {
   @override
   final String? id;
   final String surname;
@@ -18,7 +18,7 @@ class Family with DataModel<Family> {
   final BelongsTo<House>? residence;
   final HasMany<Dog>? dogs;
 
-  Family({
+  Familia({
     this.id,
     required this.surname,
     HasMany<Person>? persons,
@@ -31,7 +31,7 @@ class Family with DataModel<Family> {
 
   @override
   bool operator ==(other) =>
-      other is Family && id == other.id && surname == other.surname;
+      other is Familia && id == other.id && surname == other.surname;
 
   @override
   int get hashCode => runtimeType.hashCode ^ id.hashCode ^ surname.hashCode;

--- a/test/_support/familia.g.dart
+++ b/test/_support/familia.g.dart
@@ -1,12 +1,12 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'family.dart';
+part of 'familia.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-Family _$FamilyFromJson(Map<String, dynamic> json) => Family(
+Familia _$FamiliaFromJson(Map<String, dynamic> json) => Familia(
       id: json['id'] as String?,
       surname: json['surname'] as String,
       persons: json['persons'] == null
@@ -24,7 +24,7 @@ Family _$FamilyFromJson(Map<String, dynamic> json) => Family(
           : HasMany<Dog>.fromJson(json['dogs'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$FamilyToJson(Family instance) {
+Map<String, dynamic> _$FamiliaToJson(Familia instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -48,12 +48,12 @@ Map<String, dynamic> _$FamilyToJson(Family instance) {
 
 // ignore_for_file: invalid_use_of_protected_member, invalid_use_of_visible_for_testing_member, non_constant_identifier_names
 
-mixin $FamilyLocalAdapter on LocalAdapter<Family> {
+mixin $FamiliaLocalAdapter on LocalAdapter<Familia> {
   @override
-  Map<String, Map<String, Object?>> relationshipsFor([Family? model]) => {
+  Map<String, Map<String, Object?>> relationshipsFor([Familia? model]) => {
         'persons': {
           'name': 'persons',
-          'inverse': 'family',
+          'inverse': 'familia',
           'type': 'people',
           'kind': 'HasMany',
           'instance': model?.persons
@@ -81,38 +81,39 @@ mixin $FamilyLocalAdapter on LocalAdapter<Family> {
       };
 
   @override
-  Family deserialize(map) {
+  Familia deserialize(map) {
     for (final key in relationshipsFor().keys) {
       map[key] = {
         '_': [map[key], !map.containsKey(key)],
       };
     }
-    return _$FamilyFromJson(map);
+    return _$FamiliaFromJson(map);
   }
 
   @override
-  Map<String, dynamic> serialize(model) => _$FamilyToJson(model);
+  Map<String, dynamic> serialize(model) => _$FamiliaToJson(model);
 }
 
 // ignore: must_be_immutable
-class $FamilyHiveLocalAdapter = HiveLocalAdapter<Family>
-    with $FamilyLocalAdapter;
+class $FamiliaHiveLocalAdapter = HiveLocalAdapter<Familia>
+    with $FamiliaLocalAdapter;
 
-class $FamilyRemoteAdapter = RemoteAdapter<Family> with NothingMixin;
+class $FamiliaRemoteAdapter = RemoteAdapter<Familia> with NothingMixin;
 
 //
 
-final familiesRemoteAdapterProvider = Provider<RemoteAdapter<Family>>((ref) =>
-    $FamilyRemoteAdapter(
-        $FamilyHiveLocalAdapter(ref.read), familyProvider, familiesProvider));
+final familiaRemoteAdapterProvider = Provider<RemoteAdapter<Familia>>((ref) =>
+    $FamiliaRemoteAdapter(
+        $FamiliaHiveLocalAdapter(ref.read), familiumProvider, familiaProvider));
 
-final familiesRepositoryProvider =
-    Provider<Repository<Family>>((ref) => Repository<Family>(ref.read));
+final familiaRepositoryProvider =
+    Provider<Repository<Familia>>((ref) => Repository<Familia>(ref.read));
 
-final _familyProvider = StateNotifierProvider.autoDispose
-    .family<DataStateNotifier<Family?>, DataState<Family?>, WatchArgs<Family>>(
-        (ref, args) {
-  final adapter = ref.watch(familiesRemoteAdapterProvider);
+final _familiumProvider = StateNotifierProvider.autoDispose.family<
+    DataStateNotifier<Familia?>,
+    DataState<Familia?>,
+    WatchArgs<Familia>>((ref, args) {
+  final adapter = ref.watch(familiaRemoteAdapterProvider);
   final notifier =
       adapter.strategies.watchersOne[args.watcher] ?? adapter.watchOneNotifier;
   return notifier(args.id!,
@@ -123,15 +124,16 @@ final _familyProvider = StateNotifierProvider.autoDispose
       finder: args.finder);
 });
 
-AutoDisposeStateNotifierProvider<DataStateNotifier<Family?>, DataState<Family?>>
-    familyProvider(Object? id,
+AutoDisposeStateNotifierProvider<DataStateNotifier<Familia?>,
+        DataState<Familia?>>
+    familiumProvider(Object? id,
         {bool? remote,
         Map<String, dynamic>? params,
         Map<String, String>? headers,
-        AlsoWatch<Family>? alsoWatch,
+        AlsoWatch<Familia>? alsoWatch,
         String? finder,
         String? watcher}) {
-  return _familyProvider(WatchArgs(
+  return _familiumProvider(WatchArgs(
       id: id,
       remote: remote,
       params: params,
@@ -141,11 +143,11 @@ AutoDisposeStateNotifierProvider<DataStateNotifier<Family?>, DataState<Family?>>
       watcher: watcher));
 }
 
-final _familiesProvider = StateNotifierProvider.autoDispose.family<
-    DataStateNotifier<List<Family>>,
-    DataState<List<Family>>,
-    WatchArgs<Family>>((ref, args) {
-  final adapter = ref.watch(familiesRemoteAdapterProvider);
+final _familiaProvider = StateNotifierProvider.autoDispose.family<
+    DataStateNotifier<List<Familia>>,
+    DataState<List<Familia>>,
+    WatchArgs<Familia>>((ref, args) {
+  final adapter = ref.watch(familiaRemoteAdapterProvider);
   final notifier =
       adapter.strategies.watchersAll[args.watcher] ?? adapter.watchAllNotifier;
   return notifier(
@@ -156,16 +158,16 @@ final _familiesProvider = StateNotifierProvider.autoDispose.family<
       finder: args.finder);
 });
 
-AutoDisposeStateNotifierProvider<DataStateNotifier<List<Family>>,
-        DataState<List<Family>>>
-    familiesProvider(
+AutoDisposeStateNotifierProvider<DataStateNotifier<List<Familia>>,
+        DataState<List<Familia>>>
+    familiaProvider(
         {bool? remote,
         Map<String, dynamic>? params,
         Map<String, String>? headers,
         bool? syncLocal,
         String? finder,
         String? watcher}) {
-  return _familiesProvider(WatchArgs(
+  return _familiaProvider(WatchArgs(
       remote: remote,
       params: params,
       headers: headers,
@@ -174,17 +176,17 @@ AutoDisposeStateNotifierProvider<DataStateNotifier<List<Family>>,
       watcher: watcher));
 }
 
-extension FamilyDataX on Family {
+extension FamiliaDataX on Familia {
   /// Initializes "fresh" models (i.e. manually instantiated) to use
   /// [save], [delete] and so on.
   ///
   /// Can be obtained via `ref.read`, `container.read`
-  Family init(Reader read, {bool save = true}) {
-    final repository = internalLocatorFn(familiesRepositoryProvider, read);
+  Familia init(Reader read, {bool save = true}) {
+    final repository = internalLocatorFn(familiaRepositoryProvider, read);
     final updatedModel =
         repository.remoteAdapter.initializeModel(this, save: save);
     return save ? updatedModel : this;
   }
 }
 
-extension FamilyDataRepositoryX on Repository<Family> {}
+extension FamiliaDataRepositoryX on Repository<Familia> {}

--- a/test/_support/house.dart
+++ b/test/_support/house.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_data/flutter_data.dart';
 import 'package:json_annotation/json_annotation.dart';
 
-import 'family.dart';
+import 'familia.dart';
 
 part 'house.g.dart';
 
@@ -12,12 +12,12 @@ class House with DataModel<House> {
   final String? id;
   final String address;
   @DataRelationship(inverse: 'residence')
-  final BelongsTo<Family> owner;
+  final BelongsTo<Familia> owner;
 
   House({
     this.id,
     required this.address,
-    BelongsTo<Family>? owner,
+    BelongsTo<Familia>? owner,
   }) : owner = owner ?? BelongsTo();
 
   @override

--- a/test/_support/house.g.dart
+++ b/test/_support/house.g.dart
@@ -11,7 +11,7 @@ House _$HouseFromJson(Map<String, dynamic> json) => House(
       address: json['address'] as String,
       owner: json['owner'] == null
           ? null
-          : BelongsTo<Family>.fromJson(json['owner'] as Map<String, dynamic>),
+          : BelongsTo<Familia>.fromJson(json['owner'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$HouseToJson(House instance) => <String, dynamic>{
@@ -32,7 +32,7 @@ mixin $HouseLocalAdapter on LocalAdapter<House> {
         'owner': {
           'name': 'owner',
           'inverse': 'residence',
-          'type': 'families',
+          'type': 'familia',
           'kind': 'BelongsTo',
           'instance': model?.owner
         }

--- a/test/_support/person.dart
+++ b/test/_support/person.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter_data/flutter_data.dart';
-import 'family.dart';
+import 'familia.dart';
 
 part 'person.g.dart';
 
@@ -13,14 +13,14 @@ class Person with DataModel<Person> {
   final String? id;
   final String name;
   final int? age;
-  final BelongsTo<Family> family;
+  final BelongsTo<Familia> familia;
 
   Person({
     this.id,
     required this.name,
     this.age,
-    BelongsTo<Family>? family,
-  }) : family = family ?? BelongsTo();
+    BelongsTo<Familia>? familia,
+  }) : familia = familia ?? BelongsTo();
 
   // testing without jsonserializable
   // also, simulates a @JsonKey(name: '_id) on `id`
@@ -28,16 +28,16 @@ class Person with DataModel<Person> {
         id: json['_id'] as String?,
         name: json['name'] as String,
         age: json['age'] as int?,
-        family: json['family'] == null
+        familia: json['familia'] == null
             ? null
-            : BelongsTo.fromJson(json['family'] as Map<String, dynamic>),
+            : BelongsTo.fromJson(json['familia'] as Map<String, dynamic>),
       );
 
   Map<String, dynamic> toJson() => {
         '_id': id,
         'name': name,
         'age': age,
-        'family': family.toJson(),
+        'familia': familia.toJson(),
       };
 
   @override

--- a/test/_support/person.g.dart
+++ b/test/_support/person.g.dart
@@ -11,12 +11,12 @@ part of 'person.dart';
 mixin $PersonLocalAdapter on LocalAdapter<Person> {
   @override
   Map<String, Map<String, Object?>> relationshipsFor([Person? model]) => {
-        'family': {
-          'name': 'family',
+        'familia': {
+          'name': 'familia',
           'inverse': 'persons',
-          'type': 'families',
+          'type': 'familia',
           'kind': 'BelongsTo',
-          'instance': model?.family
+          'instance': model?.familia
         }
       };
 

--- a/test/_support/pet.dart
+++ b/test/_support/pet.dart
@@ -13,8 +13,8 @@ abstract class Pet<T extends Pet<T>> with DataModel<T> {
 @JsonSerializable()
 class Dog extends Pet<Dog> {
   final String name;
-  // NOTE: do not add BelongsTo<Family>, we are testing that
-  // one-way relationship (Family: HasMany<Dog>)
+  // NOTE: do not add BelongsTo<Familia>, we are testing that
+  // one-way relationship (Familia: HasMany<Dog>)
   Dog({String? id, required this.name}) : super(id);
   factory Dog.fromJson(Map<String, dynamic> json) => _$DogFromJson(json);
   Map<String, dynamic> toJson() => _$DogToJson(this);

--- a/test/_support/setup.dart
+++ b/test/_support/setup.dart
@@ -5,7 +5,7 @@ import 'package:http/testing.dart';
 
 import '../mocks.dart';
 import 'book.dart';
-import 'family.dart';
+import 'familia.dart';
 import 'house.dart';
 import 'node.dart';
 import 'person.dart';
@@ -20,10 +20,10 @@ late ProviderContainer container;
 late GraphNotifier graph;
 
 late RemoteAdapter<House> houseRemoteAdapter;
-late RemoteAdapter<Family> familyRemoteAdapter;
+late RemoteAdapter<Familia> familiaRemoteAdapter;
 late RemoteAdapter<Person> personRemoteAdapter;
 
-late Repository<Family> familyRepository;
+late Repository<Familia> familiaRepository;
 late Repository<House> houseRepository;
 late Repository<Person> personRepository;
 late Repository<Dog> dogRepository;
@@ -63,13 +63,13 @@ void setUpFn() async {
 
   final adapterGraph = <String, RemoteAdapter<DataModel>>{
     'houses': container.read(housesRemoteAdapterProvider),
-    'families': container.read(familiesRemoteAdapterProvider),
+    'familia': container.read(familiaRemoteAdapterProvider),
     'people': container.read(peopleRemoteAdapterProvider),
     'dogs': container.read(dogsRemoteAdapterProvider),
   };
 
   houseRemoteAdapter = container.read(housesRemoteAdapterProvider);
-  familyRemoteAdapter = container.read(familiesRemoteAdapterProvider);
+  familiaRemoteAdapter = container.read(familiaRemoteAdapterProvider);
   personRemoteAdapter = container.read(peopleRemoteAdapterProvider);
 
   await container.read(graphNotifierProvider).initialize();
@@ -80,8 +80,8 @@ void setUpFn() async {
         adapters: adapterGraph,
       );
 
-  familyRepository =
-      await container.read(familiesRepositoryProvider).initialize(
+  familiaRepository =
+      await container.read(familiaRepositoryProvider).initialize(
             remote: true,
             verbose: false,
             adapters: adapterGraph,
@@ -132,7 +132,7 @@ void tearDownFn() async {
   // Equivalent to generated in `main.data.dart`
   dispose?.call();
   houseRepository.dispose();
-  familyRepository.dispose();
+  familiaRepository.dispose();
   personRepository.dispose();
   dogRepository.dispose();
   nodeRepository.dispose();

--- a/test/graph/graph_notifier_test.dart
+++ b/test/graph/graph_notifier_test.dart
@@ -3,7 +3,7 @@ import 'dart:math';
 import 'package:flutter_data/flutter_data.dart';
 import 'package:test/test.dart';
 
-import '../_support/family.dart';
+import '../_support/familia.dart';
 import '../_support/house.dart';
 import '../_support/person.dart';
 import '../_support/setup.dart';
@@ -119,15 +119,15 @@ void main() async {
   });
 
   test('by key', () {
-    graph.getKeyForId('families', '3', keyIfAbsent: 'families#c3c3c3');
+    graph.getKeyForId('familia', '3', keyIfAbsent: 'familia#c3c3c3');
 
-    final key = 'families#c3c3c3';
-    expect(key, graph.getKeyForId('families', '3'));
+    final key = 'familia#c3c3c3';
+    expect(key, graph.getKeyForId('familia', '3'));
   });
 
   test('two models with id should get the same key', () {
-    expect(graph.getKeyForId('families', '2812', keyIfAbsent: 'f1'),
-        graph.getKeyForId('families', '2812', keyIfAbsent: 'f1'));
+    expect(graph.getKeyForId('familia', '2812', keyIfAbsent: 'f1'),
+        graph.getKeyForId('familia', '2812', keyIfAbsent: 'f1'));
   });
 
   test('should prioritize ID', () {
@@ -168,7 +168,7 @@ void main() async {
     final div = 19;
 
     for (var i = 0; i < length; i++) {
-      final family = Family(
+      final familia = Familia(
         id: '$i',
         surname: 'Smith',
         residence: residence.asBelongsTo,
@@ -177,19 +177,19 @@ void main() async {
 
       // add some people
       if (i % div == 0) {
-        family.persons
+        familia.persons
             .add(Person(name: 'new kid #$i', age: i).init(container.read));
       }
 
       // remove some residence relationships
       if (Random().nextBool()) {
-        family.residence!.value = null;
+        familia.residence!.value = null;
       }
 
-      await family.save();
+      await familia.save();
     }
 
-    expect(graph.toMap().keys.where((k) => k.startsWith('families')),
+    expect(graph.toMap().keys.where((k) => k.startsWith('familia')),
         hasLength(length));
   });
 

--- a/test/model/data_model_test.dart
+++ b/test/model/data_model_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_data/flutter_data.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
-import '../_support/family.dart';
+import '../_support/familia.dart';
 import '../_support/person.dart';
 import '../_support/pet.dart';
 import '../_support/setup.dart';
@@ -13,32 +13,32 @@ void main() async {
   tearDown(tearDownFn);
 
   test('uninitialized throws an assertion error', () {
-    final family = Family(id: '1', surname: 'Johnson');
-    expectLater(family.save, throwsA(isA<AssertionError>()));
-    expectLater(family.delete, throwsA(isA<AssertionError>()));
-    expectLater(family.reload, throwsA(isA<AssertionError>()));
+    final familia = Familia(id: '1', surname: 'Johnson');
+    expectLater(familia.save, throwsA(isA<AssertionError>()));
+    expectLater(familia.delete, throwsA(isA<AssertionError>()));
+    expectLater(familia.reload, throwsA(isA<AssertionError>()));
   });
 
   test('init', () async {
-    final family = Family(id: '55', surname: 'Kelley').init(container.read);
+    final familia = Familia(id: '55', surname: 'Kelley').init(container.read);
     final model =
-        Person(id: '1', name: 'John', age: 27, family: family.asBelongsTo)
+        Person(id: '1', name: 'John', age: 27, familia: familia.asBelongsTo)
             .init(container.read);
 
     // (1) it wires up the relationship (setOwnerInRelationship)
-    expect(model.family.key, graph.getKeyForId('families', '55'));
+    expect(model.familia.key, graph.getKeyForId('familia', '55'));
 
     // (2) it saves the model locally
     expect(model, await personRepository.findOne(model.id!, remote: false));
   });
 
   test('findOne (reload) without ID', () async {
-    final family = Family(surname: 'Zliedowski').init(container.read);
-    final f2 = Family(surname: 'Zliedowski').was(family);
+    final familia = Familia(surname: 'Zliedowski').init(container.read);
+    final f2 = Familia(surname: 'Zliedowski').was(familia);
 
-    final f3 = await family.reload(remote: false);
-    expect(keyFor(family), keyFor(f2));
-    expect(keyFor(family), keyFor(f3!));
+    final f3 = await familia.reload(remote: false);
+    expect(keyFor(familia), keyFor(f2));
+    expect(keyFor(familia), keyFor(f3!));
   });
 
   test('delete model with and without ID', () async {
@@ -122,7 +122,7 @@ void main() async {
   test('should work with subclasses', () {
     final dog = Dog(id: '2', name: 'Walker').init(container.read);
     final f =
-        Family(surname: 'Walker', dogs: {dog}.asHasMany).init(container.read);
+        Familia(surname: 'Walker', dogs: {dog}.asHasMany).init(container.read);
     expect(f.dogs!.first.name, 'Walker');
   });
 

--- a/test/model/relationship/belongs_to_test.dart
+++ b/test/model/relationship/belongs_to_test.dart
@@ -3,7 +3,7 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../../_support/book.dart';
-import '../../_support/family.dart';
+import '../../_support/familia.dart';
 import '../../_support/house.dart';
 import '../../_support/person.dart';
 import '../../_support/setup.dart';
@@ -18,48 +18,48 @@ void main() async {
     final house = House(id: '31', address: '123 Main St');
     final house2 = House(id: '2', address: '456 Main St');
 
-    final family = Family(
+    final familia = Familia(
         id: '1',
         surname: 'Smith',
         residence: BelongsTo<House>(house),
         persons: HasMany<Person>({person}));
 
-    // values are there even if family (and its relationships) are not init'd
-    expect(family.residence!.value, house);
-    expect(family.persons.toSet(), {person});
-    expect(family.persons, equals(family.persons));
+    // values are there even if familia (and its relationships) are not init'd
+    expect(familia.residence!.value, house);
+    expect(familia.persons.toSet(), {person});
+    expect(familia.persons, equals(familia.persons));
 
-    family.init(container.read);
+    familia.init(container.read);
 
     // after init, values remain the same
-    expect(family.residence!.value, house);
-    expect(family.persons.toSet(), {person});
-    expect(family.persons, equals(family.persons));
+    expect(familia.residence!.value, house);
+    expect(familia.persons.toSet(), {person});
+    expect(familia.persons, equals(familia.persons));
 
     // relationships are now associated to a key
-    expect(family.residence!.key, isNotNull);
-    expect(family.residence!.key, graph.getKeyForId('houses', '31'));
-    expect(family.residence!.id, '31');
-    expect(family.persons.keys.first, isNotNull);
-    expect(family.persons.keys.first, graph.getKeyForId('people', '1'));
+    expect(familia.residence!.key, isNotNull);
+    expect(familia.residence!.key, graph.getKeyForId('houses', '31'));
+    expect(familia.residence!.id, '31');
+    expect(familia.persons.keys.first, isNotNull);
+    expect(familia.persons.keys.first, graph.getKeyForId('people', '1'));
 
     // ensure there are not more than 1 key
-    family.residence!.value = house2;
-    expect(family.residence!.keys, hasLength(1));
-    expect(family.residence!.id, '2');
+    familia.residence!.value = house2;
+    expect(familia.residence!.keys, hasLength(1));
+    expect(familia.residence!.id, '2');
   });
 
   test('assignment with relationship initialized & uninitialized', () {
-    final family =
-        Family(id: '1', surname: 'Smith', residence: BelongsTo<House>());
+    final familia =
+        Familia(id: '1', surname: 'Smith', residence: BelongsTo<House>());
     final house = House(id: '1', address: '456 Lemon Rd');
 
-    family.residence!.value = house;
-    expect(family.residence!.value, house);
+    familia.residence!.value = house;
+    expect(familia.residence!.value, house);
 
-    family.init(container.read);
-    family.residence!.value = house; // assigning again shouldn't affect
-    expect(family.residence!.value, house);
+    familia.init(container.read);
+    familia.residence!.value = house; // assigning again shouldn't affect
+    expect(familia.residence!.value, house);
   });
 
   test('use fromJson constructor without initialization', () {
@@ -75,31 +75,31 @@ void main() async {
   });
 
   test('watch', () async {
-    final family = Family(
+    final familia = Familia(
       id: '22',
       surname: 'Besson',
       residence: BelongsTo<House>(),
     ).init(container.read);
 
-    final notifier = family.residence!.watch();
+    final notifier = familia.residence!.watch();
     final listener = Listener<House?>();
     dispose = notifier.addListener(listener, fireImmediately: false);
 
-    family.residence!.value = House(id: '2', address: '456 Main St');
+    familia.residence!.value = House(id: '2', address: '456 Main St');
     await oneMs();
 
     verify(listener(argThat(
       isA<House>().having((h) => h.address, 'address', startsWith('456')),
     ))).called(1);
 
-    family.residence!.value = House(id: '1', address: '123 Main St');
+    familia.residence!.value = House(id: '1', address: '123 Main St');
     await oneMs();
 
     verify(listener(argThat(
       isA<House>().having((h) => h.address, 'address', startsWith('123')),
     ))).called(1);
 
-    family.residence!.value = null;
+    familia.residence!.value = null;
     await oneMs();
 
     verify(listener(argThat(isNull))).called(1);
@@ -109,28 +109,28 @@ void main() async {
     final person = Person(name: 'Cecil', age: 2).init(container.read);
     final house =
         House(id: '1', address: '21 Coconut Trail').init(container.read);
-    final family = Family(
+    final familia = Familia(
             id: '2',
             surname: 'Raoult',
             residence: house.asBelongsTo,
             persons: {person}.asHasMany)
         .init(container.read);
 
-    // reusing a BelongsTo<Family> (`house.owner`) to add a person
+    // reusing a BelongsTo<Familia> (`house.owner`) to add a person
     // adds the inverse relationship
-    expect(family.persons.length, 1);
-    Person(name: 'Junior', age: 12, family: house.owner).init(container.read);
-    expect(family.persons.length, 2);
+    expect(familia.persons.length, 1);
+    Person(name: 'Junior', age: 12, familia: house.owner).init(container.read);
+    expect(familia.persons.length, 2);
 
     // an empty reused relationship should not fail
     final house2 =
-        House(id: '17', address: '798 Birkham Rd', owner: BelongsTo<Family>())
+        House(id: '17', address: '798 Birkham Rd', owner: BelongsTo<Familia>())
             .init(container.read);
 
-    // trying to add walter to a null family does nothing
-    Person(name: 'Walter', age: 55, family: house2.owner).init(container.read);
+    // trying to add walter to a null familia does nothing
+    Person(name: 'Walter', age: 55, familia: house2.owner).init(container.read);
 
-    expect(family.persons.length, 2);
+    expect(familia.persons.length, 2);
   });
 
   test('remove relationship', () async {

--- a/test/model/relationship/has_many_test.dart
+++ b/test/model/relationship/has_many_test.dart
@@ -3,7 +3,7 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../../_support/book.dart';
-import '../../_support/family.dart';
+import '../../_support/familia.dart';
 import '../../_support/house.dart';
 import '../../_support/person.dart';
 import '../../_support/setup.dart';
@@ -15,7 +15,7 @@ void main() async {
 
   test('behaves like a collection (without init/models)', () {
     final anne = Person(name: 'Anne', age: 59);
-    final f1 = Family(surname: 'Mayer', persons: {anne}.asHasMany);
+    final f1 = Familia(surname: 'Mayer', persons: {anne}.asHasMany);
 
     f1.persons.add(anne);
     f1.persons.add(anne);
@@ -33,7 +33,7 @@ void main() async {
     final pete = Person(name: 'Pete', age: 29);
     final anne = Person(name: 'Anne', age: 59);
     final residence = House(address: '1322 Hill Rd');
-    final f2 = Family(
+    final f2 = Familia(
       surname: 'Sumberg',
       persons: {pete}.asHasMany,
       cottage: BelongsTo(),
@@ -58,16 +58,16 @@ void main() async {
   });
 
   test('assignment with relationship initialized & uninitialized', () {
-    final family = Family(id: '1', surname: 'Smith', persons: HasMany());
+    final familia = Familia(id: '1', surname: 'Smith', persons: HasMany());
     final person = Person(id: '1', name: 'Flavio', age: 12);
 
-    family.persons.add(person);
-    expect(family.persons.contains(person), isTrue);
+    familia.persons.add(person);
+    expect(familia.persons.contains(person), isTrue);
 
-    family.init(container.read);
+    familia.init(container.read);
 
-    family.persons.add(person);
-    expect(family.persons.contains(person), isTrue);
+    familia.persons.add(person);
+    expect(familia.persons.contains(person), isTrue);
   });
 
   test('use fromJson constructor without initialization', () {
@@ -83,41 +83,41 @@ void main() async {
   });
 
   test('watch', () async {
-    final family = Family(
+    final familia = Familia(
       id: '1',
       surname: 'Smith',
       persons: HasMany<Person>(),
     ).init(container.read);
 
-    final notifier = family.persons.watch();
+    final notifier = familia.persons.watch();
     final listener = Listener<Set<Person>>();
     dispose = notifier.addListener(listener, fireImmediately: false);
 
     final p1 = Person(name: 'a', age: 1);
     final p2 = Person(name: 'b', age: 2);
 
-    family.persons.add(p1);
+    familia.persons.add(p1);
     await oneMs();
 
     verify(listener({p1})).called(1);
 
-    family.persons.add(p2);
+    familia.persons.add(p2);
     await oneMs();
 
     verify(listener({p1, p2})).called(1);
 
-    family.persons.add(p2);
+    familia.persons.add(p2);
     await oneMs();
 
     // doesn't show up as p2 was already present!
     verifyNever(listener({p1, p2}));
 
-    family.persons.remove(p1);
+    familia.persons.remove(p1);
     await oneMs();
 
     verify(listener({p2})).called(1);
 
-    family.persons.add(p1);
+    familia.persons.add(p1);
     await oneMs();
 
     verify(listener({p1, p2})).called(1);

--- a/test/model/relationship/relationship_test.dart
+++ b/test/model/relationship/relationship_test.dart
@@ -3,7 +3,7 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../../_support/book.dart';
-import '../../_support/family.dart';
+import '../../_support/familia.dart';
 import '../../_support/house.dart';
 import '../../_support/node.dart';
 import '../../_support/person.dart';
@@ -22,7 +22,7 @@ void main() async {
 
     // since we're passing a key (not an ID)
     // we MUST use the local adapter serializer
-    final f1 = familyRemoteAdapter.localAdapter.deserialize({
+    final f1 = familiaRemoteAdapter.localAdapter.deserialize({
       'id': '1',
       'surname': 'Rose',
       'residence': residenceKey
@@ -40,7 +40,7 @@ void main() async {
     // residence is omitted, but persons is included (no people exist yet)
     final personKey =
         graph.getKeyForId('people', '1', keyIfAbsent: 'people#a1a1a1');
-    final f1b = familyRemoteAdapter.localAdapter.deserialize({
+    final f1b = familiaRemoteAdapter.localAdapter.deserialize({
       'id': '1',
       'surname': 'Rose',
       'persons': [personKey],
@@ -57,7 +57,7 @@ void main() async {
     expect(f1b.persons.toSet(), {p1});
 
     // relationships are omitted - so they remain unchanged
-    final f1c = familyRemoteAdapter.localAdapter
+    final f1c = familiaRemoteAdapter.localAdapter
         .deserialize({'id': '1', 'surname': 'Rose'}).init(container.read);
     expect(f1c.persons.toSet(), {p1});
     expect(f1c.residence!.value, isNotNull);
@@ -65,20 +65,20 @@ void main() async {
     final p2 = Person(id: '2', name: 'Brian', age: 55).init(container.read);
 
     // persons has changed from [1] to [2]
-    final f1d = familyRemoteAdapter.localAdapter.deserialize({
+    final f1d = familiaRemoteAdapter.localAdapter.deserialize({
       'id': '1',
       'surname': 'Rose',
       'persons': [keyFor(p2)]
     }).init(container.read);
     // persons should be exactly equal to p2 (Brian)
     expect(f1d.persons.toSet(), {p2});
-    // without directly modifying p2, its family should be automatically updated
-    expect(p2.family.value, f1d);
-    // and by the same token, p1's family should now be null
-    expect(p1.family.value, isNull);
+    // without directly modifying p2, its familia should be automatically updated
+    expect(p2.familia.value, f1d);
+    // and by the same token, p1's familia should now be null
+    expect(p1.familia.value, isNull);
 
     // relationships are explicitly set to null
-    final f1e = familyRemoteAdapter.localAdapter.deserialize({
+    final f1e = familiaRemoteAdapter.localAdapter.deserialize({
       'id': '1',
       'surname': 'Rose',
       'persons': null,
@@ -97,40 +97,40 @@ void main() async {
     final h1 = houseRemoteAdapter.localAdapter.deserialize({
       'id': '1',
       'address': '123 Main St',
-      'owner': 'families#a1a1a1'
+      'owner': 'familia#a1a1a1'
     }).init(container.read);
     expect(h1.owner.value, isNull);
     expect(keyFor(h1), isNotNull);
 
-    graph.getKeyForId('family', '1', keyIfAbsent: 'families#a1a1a1');
+    graph.getKeyForId('familia', '1', keyIfAbsent: 'familia#a1a1a1');
 
     // once it does
-    final family = Family(id: '1', surname: 'Rose', residence: BelongsTo())
+    final familia = Familia(id: '1', surname: 'Rose', residence: BelongsTo())
         .init(container.read);
     // it's automatically wired up & inverses work correctly
-    expect(h1.owner.value, family);
+    expect(h1.owner.value, familia);
     expect(h1.owner.value!.residence!.value, h1);
   });
 
   test('scenario #2', () {
-    // (1) first load family (with relationships)
-    final family = Family(
+    // (1) first load familia (with relationships)
+    final familia = Familia(
       id: '1',
       surname: 'Jones',
       persons: HasMany.fromJson({
         '_': [
           ['people#c1c1c1', 'people#c2c2c2', 'people#c3c3c3'],
           false,
-          familyRepository
+          familiaRepository
         ]
       }),
       residence: BelongsTo.fromJson({
-        '_': ['houses#c98d1b', false, familyRepository]
+        '_': ['houses#c98d1b', false, familiaRepository]
       }),
     ).init(container.read);
 
-    expect(family.residence!.key, isNotNull);
-    expect(family.persons.keys.length, 3);
+    expect(familia.residence!.key, isNotNull);
+    expect(familia.persons.keys.length, 3);
 
     // associate ids with keys
     graph.getKeyForId('people', '1', keyIfAbsent: 'people#c1c1c1');
@@ -139,7 +139,7 @@ void main() async {
     graph.getKeyForId('houses', '98', keyIfAbsent: 'houses#c98d1b');
 
     // test ids
-    expect(family.persons.ids, {'1', '2', '3'});
+    expect(familia.persons.ids, {'1', '2', '3'});
 
     // (2) then load persons
 
@@ -147,53 +147,53 @@ void main() async {
     Person(id: '2', name: 'z2', age: 33).init(container.read);
 
     // (3) assert two first are linked, third one null, residence is null
-    expect(family.persons.length, 2);
-    expect(family.residence!.value, isNull);
+    expect(familia.persons.length, 2);
+    expect(familia.residence!.value, isNull);
 
     // (4) load the last person and assert it exists now
     final p3 = Person(id: '3', name: 'z3', age: 3).init(container.read);
-    expect(p3.family.value, family);
+    expect(p3.familia.value, familia);
 
-    // (5) load family and assert it exists now
+    // (5) load familia and assert it exists now
     final house =
         House(id: '98', address: '21 Coconut Trail').init(container.read);
-    expect(house.owner.value, family);
-    expect(family.residence!.value!.address, endsWith('Trail'));
-    expect(house.owner.value, family); // same, passes here again
+    expect(house.owner.value, familia);
+    expect(familia.residence!.value!.address, endsWith('Trail'));
+    expect(house.owner.value, familia); // same, passes here again
   });
 
   test('scenario #3', () {
     final igor = Person(name: 'Igor', age: 33).init(container.read);
-    final f1 = Family(surname: 'Kamchatka', persons: {igor}.asHasMany)
+    final f1 = Familia(surname: 'Kamchatka', persons: {igor}.asHasMany)
         .init(container.read);
-    expect(f1.persons.first.family.value, f1);
+    expect(f1.persons.first.familia.value, f1);
 
-    final igor1b =
-        Person(name: 'Igor', age: 33, family: BelongsTo()).init(container.read);
-
-    final f1b = Family(surname: 'Kamchatka', persons: {igor1b}.asHasMany)
+    final igor1b = Person(name: 'Igor', age: 33, familia: BelongsTo())
         .init(container.read);
-    expect(f1b.persons.first.family.value!.surname, 'Kamchatka');
+
+    final f1b = Familia(surname: 'Kamchatka', persons: {igor1b}.asHasMany)
+        .init(container.read);
+    expect(f1b.persons.first.familia.value!.surname, 'Kamchatka');
 
     final f2 =
-        Family(surname: 'Kamchatka', persons: HasMany()).init(container.read);
-    final igor2 =
-        Person(name: 'Igor', age: 33, family: BelongsTo()).init(container.read);
+        Familia(surname: 'Kamchatka', persons: HasMany()).init(container.read);
+    final igor2 = Person(name: 'Igor', age: 33, familia: BelongsTo())
+        .init(container.read);
     f2.persons.add(igor2);
-    expect(f2.persons.first.family.value!.surname, 'Kamchatka');
+    expect(f2.persons.first.familia.value!.surname, 'Kamchatka');
 
     f2.persons.remove(igor2);
     expect(f2.persons, isEmpty);
 
     final residence =
         House(address: 'Sakharova Prospekt, 19').init(container.read);
-    final f3 = Family(surname: 'Kamchatka', residence: residence.asBelongsTo)
+    final f3 = Familia(surname: 'Kamchatka', residence: residence.asBelongsTo)
         .init(container.read);
     expect(f3.residence!.value!.owner.value!.surname, 'Kamchatka');
     f3.residence!.value = null;
     expect(f3.residence!.value, isNull);
 
-    final f4 = Family(surname: 'Kamchatka', residence: BelongsTo())
+    final f4 = Familia(surname: 'Kamchatka', residence: BelongsTo())
         .init(container.read);
     f4.residence!.value =
         House(address: 'Sakharova Prospekt, 19').init(container.read);
@@ -202,36 +202,36 @@ void main() async {
 
   test('scenario #4: maintain relationship reference validity', () async {
     final brian = Person(name: 'Brian', age: 52).init(container.read);
-    final family =
-        Family(id: '229', surname: 'Rose', persons: {brian}.asHasMany)
+    final familia =
+        Familia(id: '229', surname: 'Rose', persons: {brian}.asHasMany)
             .init(container.read);
-    expect(family.persons.length, 1);
+    expect(familia.persons.length, 1);
 
-    // new family comes in locally with no persons relationship info
-    final family2 = Family(id: '229', surname: 'Rose', persons: HasMany())
+    // new familia comes in locally with no persons relationship info
+    final familia2 = Familia(id: '229', surname: 'Rose', persons: HasMany())
         .init(container.read);
     // it should keep the relationships unaltered
-    expect(family2.persons.length, 1);
+    expect(familia2.persons.length, 1);
 
-    // new family comes in from API (simulate) with no persons relationship info
-    final family3 =
-        (familyRemoteAdapter.deserialize({'id': '229', 'surname': 'Rose'}))
+    // new familia comes in from API (simulate) with no persons relationship info
+    final familia3 =
+        (familiaRemoteAdapter.deserialize({'id': '229', 'surname': 'Rose'}))
             .model!
             .init(container.read);
     // it should keep the relationships unaltered
-    expect(family3.persons.length, 1);
+    expect(familia3.persons.length, 1);
 
-    // new family comes in from API (simulate) with empty persons relationship
-    final family4 = (familyRemoteAdapter
+    // new familia comes in from API (simulate) with empty persons relationship
+    final familia4 = (familiaRemoteAdapter
             .deserialize({'id': '229', 'surname': 'Rose', 'persons': []}))
         .model!
         .init(container.read);
     // it should keep the relationships unaltered
-    expect(family4.persons.length, 0);
+    expect(familia4.persons.length, 0);
 
     // since we're passing a key (not an ID)
     // we MUST use the local adapter serializer
-    final family5 = familyRemoteAdapter.localAdapter.deserialize({
+    final familia5 = familiaRemoteAdapter.localAdapter.deserialize({
       'id': '229',
       'surname': 'Rose',
       'persons': ['people#231aaa']
@@ -239,14 +239,14 @@ void main() async {
 
     graph.getKeyForId('people', '231', keyIfAbsent: 'people#231aaa');
     final axl = Person(id: '231', name: 'Axl', age: 58).init(container.read);
-    expect(family5.persons.toSet(), {axl});
+    expect(familia5.persons.toSet(), {axl});
   });
 
   test('scenario #5: one-way relationships', () {
     // relationships that don't have an inverse
     final jerry = Dog(name: 'Jerry');
     final zoe = Dog(name: 'Zoe');
-    final f1 = Family(surname: 'Carlson', dogs: {jerry, zoe}.asHasMany)
+    final f1 = Familia(surname: 'Carlson', dogs: {jerry, zoe}.asHasMany)
         .init(container.read);
     expect(f1.dogs!.toSet(), {jerry, zoe});
   });

--- a/test/repository/local_adapter_test.dart
+++ b/test/repository/local_adapter_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_data/flutter_data.dart';
 import 'package:test/test.dart';
 
-import '../_support/family.dart';
+import '../_support/familia.dart';
 import '../_support/house.dart';
 import '../_support/person.dart';
 import '../_support/setup.dart';
@@ -11,51 +11,51 @@ void main() async {
   tearDown(tearDownFn);
 
   test('deserialize existing (with save)', () {
-    final family = Family(surname: 'Moletto').init(container.read);
+    final familia = Familia(surname: 'Moletto').init(container.read);
 
     // simulate "save"
-    graph.getKeyForId('families', '1098', keyIfAbsent: keyFor(family));
-    final family2 = familyRemoteAdapter.localAdapter
+    graph.getKeyForId('familia', '1098', keyIfAbsent: keyFor(familia));
+    final familia2 = familiaRemoteAdapter.localAdapter
         .deserialize({'id': '1098', 'surname': 'Moletto'}).init(container.read);
 
-    expect(family2, Family(id: '1098', surname: 'Moletto'));
+    expect(familia2, Familia(id: '1098', surname: 'Moletto'));
     expect(
-        (familyRemoteAdapter.localAdapter as HiveLocalAdapter<Family>)
+        (familiaRemoteAdapter.localAdapter as HiveLocalAdapter<Familia>)
             .box!
             .keys,
-        [keyFor(family2)]);
+        [keyFor(familia2)]);
   });
 
   test('deserialize many local for same remote ID', () {
-    final family = Family(surname: 'Moletto').init(container.read);
-    final family2 = Family(surname: 'Zandiver').init(container.read);
+    final familia = Familia(surname: 'Moletto').init(container.read);
+    final familia2 = Familia(surname: 'Zandiver').init(container.read);
 
-    // simulate "save" for family
-    graph.getKeyForId('families', '1298', keyIfAbsent: keyFor(family));
-    final family1b = familyRemoteAdapter.localAdapter.deserialize({
+    // simulate "save" for familia
+    graph.getKeyForId('familia', '1298', keyIfAbsent: keyFor(familia));
+    final familia1b = familiaRemoteAdapter.localAdapter.deserialize({
       'id': '1298',
       'surname': 'Helsinki',
     }).init(container.read);
 
-    // simulate "save" for family2
-    graph.getKeyForId('families', '1298', keyIfAbsent: keyFor(family2));
-    final family2b = familyRemoteAdapter.localAdapter.deserialize({
+    // simulate "save" for familia2
+    graph.getKeyForId('familia', '1298', keyIfAbsent: keyFor(familia2));
+    final familia2b = familiaRemoteAdapter.localAdapter.deserialize({
       'id': '1298',
       'surname': 'Oslo',
     }).init(container.read);
 
     // since obj returned with same ID
-    expect(keyFor(family1b), keyFor(family2b));
+    expect(keyFor(familia1b), keyFor(familia2b));
   });
 
   test('local serialize', () {
     final p1r = {Person(id: '1', name: 'Franco', age: 28)}.asHasMany;
     final h1r = House(id: '1', address: '123 Main St').asBelongsTo;
 
-    final family =
-        Family(id: '1', surname: 'Smith', residence: h1r, persons: p1r);
+    final familia =
+        Familia(id: '1', surname: 'Smith', residence: h1r, persons: p1r);
 
-    final map = familyRemoteAdapter.localAdapter.serialize(family);
+    final map = familiaRemoteAdapter.localAdapter.serialize(familia);
     expect(map, {
       'id': '1',
       'surname': 'Smith',
@@ -75,10 +75,10 @@ void main() async {
       'persons': p1r.keys,
     };
 
-    final family = familyRemoteAdapter.localAdapter.deserialize(map);
+    final familia = familiaRemoteAdapter.localAdapter.deserialize(map);
     expect(
-        family,
-        Family(
+        familia,
+        Familia(
           id: '1',
           surname: 'Smith',
           residence: h1r,
@@ -97,17 +97,17 @@ void main() async {
       'persons': [keyFor(person)]
     };
 
-    final family =
-        familyRemoteAdapter.localAdapter.deserialize(obj).init(container.read);
+    final familia =
+        familiaRemoteAdapter.localAdapter.deserialize(obj).init(container.read);
 
-    expect(family, Family(id: '1', surname: 'Smith'));
-    expect(family.residence!.value!.address, '123 Main St');
-    expect(family.persons.first.age, 21);
+    expect(familia, Familia(id: '1', surname: 'Smith'));
+    expect(familia.residence!.value!.address, '123 Main St');
+    expect(familia.persons.first.age, 21);
   });
 
   test('hive adapter typeId', () {
-    final a1 = familyRemoteAdapter.localAdapter as HiveLocalAdapter<Family>;
-    final a1b = familyRemoteAdapter.localAdapter as HiveLocalAdapter<Family>;
+    final a1 = familiaRemoteAdapter.localAdapter as HiveLocalAdapter<Familia>;
+    final a1b = familiaRemoteAdapter.localAdapter as HiveLocalAdapter<Familia>;
     final a2 = houseRemoteAdapter.localAdapter as HiveLocalAdapter<House>;
     final a3 = personRemoteAdapter.localAdapter as HiveLocalAdapter<Person>;
     expect(<HiveLocalAdapter<DataModel>>[a1, a1b, a2, a3].map((a) => a.typeId),

--- a/test/repository/remote_adapter_offline_test.dart
+++ b/test/repository/remote_adapter_offline_test.dart
@@ -6,7 +6,7 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import '../_support/book.dart';
-import '../_support/family.dart';
+import '../_support/familia.dart';
 import '../_support/setup.dart';
 import '../mocks.dart';
 
@@ -71,27 +71,27 @@ void main() async {
     final model = await bookAuthorRepository.findOne(19, remote: true);
     expect(model!.name, equals('Author Saved'));
     await oneMs();
-    expect(familyRepository.offlineOperations, isEmpty);
+    expect(familiaRepository.offlineOperations, isEmpty);
   });
 
   test('save', () async {
-    final listener = Listener<DataState<List<Family>>?>();
+    final listener = Listener<DataState<List<Familia>>?>();
     // listening to local changes enough
     final notifier =
-        familyRepository.remoteAdapter.watchAllNotifier(remote: false);
+        familiaRepository.remoteAdapter.watchAllNotifier(remote: false);
 
     dispose = notifier.addListener(listener, fireImmediately: true);
 
-    // sample family
-    final family = Family(id: '1', surname: 'Smith');
+    // sample familia
+    final familia = Familia(id: '1', surname: 'Smith');
 
-    // network issue persisting family
+    // network issue persisting familia
     container.read(responseProvider.notifier).state =
         TestResponse(text: (_) => throw SocketException('unreachable'));
 
     // must specify remote=true as repo's default is remote=false
-    await familyRepository.save(
-      family,
+    await familiaRepository.save(
+      familia,
       // override headers & params
       headers: {'X-Override-Name': 'Mantego'},
       params: {'overrideSecondName': 'Zorrilla'},
@@ -105,8 +105,8 @@ void main() async {
       onSuccess: (model) {
         // the surname follows `X-Override-Name` + `overrideSecondName`
         // as the save has been replayed with the original headers/params
-        expect(model, equals(Family(id: '1', surname: 'Mantego Zorrilla')));
-        return model as Family;
+        expect(model, equals(Familia(id: '1', surname: 'Mantego Zorrilla')));
+        return model as Familia;
       },
     );
     await oneMs();
@@ -121,42 +121,42 @@ void main() async {
       ),
     ).called(1);
 
-    // family is remembered as failed to persist
+    // familia is remembered as failed to persist
     expect(
-        familyRepository.offlineOperations
+        familiaRepository.offlineOperations
             .only(DataRequestType.save)
             .map((o) => o.offlineKey)
             .toList(),
-        [keyFor(family)]);
+        [keyFor(familia)]);
 
-    // try with family2
-    final family2 = Family(id: '2', surname: 'Montewicz');
+    // try with familia2
+    final familia2 = Familia(id: '2', surname: 'Montewicz');
     try {
-      await familyRepository.save(family2);
+      await familiaRepository.save(familia2);
     } catch (_) {
       // without onError, ignore exception
     }
     await oneMs();
 
-    // now two families failed to persist
+    // now two familia failed to persist
     expect(
-        familyRepository.offlineOperations
+        familiaRepository.offlineOperations
             .only(DataRequestType.save)
             .map((o) => o.offlineKey)
             .toList(),
-        [keyFor(family), keyFor(family2)]);
+        [keyFor(familia), keyFor(familia2)]);
 
     // retry saving both
-    await familyRepository.offlineOperations.retry();
-    // await 1ms for each family
+    await familiaRepository.offlineOperations.retry();
+    // await 1ms for each familia
     await oneMs();
     await oneMs();
 
     // none of them could be saved upon retry
-    expect(familyRepository.offlineOperations.map((o) => o.model),
-        equals([family, family2]));
+    expect(familiaRepository.offlineOperations.map((o) => o.model),
+        equals([familia, familia2]));
 
-    // change the response to: success for family, failure for family2
+    // change the response to: success for familia, failure for familia2
     container.read(responseProvider.notifier).state = TestResponse(
       text: (req) {
         if (req.url.pathSegments.last == '1') {
@@ -167,81 +167,81 @@ void main() async {
     );
 
     // retry
-    await familyRepository.offlineOperations.retry();
+    await familiaRepository.offlineOperations.retry();
     await oneMs();
     await oneMs();
 
-    // family2 failed on retry, operation still pending
-    expect(familyRepository.offlineOperations.map((o) => o.model),
-        equals([family2]));
+    // familia2 failed on retry, operation still pending
+    expect(familiaRepository.offlineOperations.map((o) => o.model),
+        equals([familia2]));
 
-    // change response to success for both family and family2
+    // change response to success for both familia and familia2
     container.read(responseProvider.notifier).state = TestResponse(text: (req) {
       return '{"id": "${req.url.pathSegments.last}", "surname": "Jones ${req.url.pathSegments.last}"}';
     });
 
     // retry
-    await familyRepository.offlineOperations.retry();
+    await familiaRepository.offlineOperations.retry();
     await oneMs();
     await oneMs();
 
     // should be empty as all saves succeeded
-    expect(familyRepository.offlineOperations.map((o) => o.model), isEmpty);
+    expect(familiaRepository.offlineOperations.map((o) => o.model), isEmpty);
 
-    // simulate a network issue once again for family3
+    // simulate a network issue once again for familia3
     container.read(responseProvider.notifier).state =
         TestResponse(text: (_) => throw SocketException('unreachable'));
 
-    final family3 = Family(id: '3', surname: 'Zweck').init(container.read);
+    final familia3 = Familia(id: '3', surname: 'Zweck').init(container.read);
     try {
-      await family3.save(remote: true);
+      await familia3.save(remote: true);
     } catch (_) {
       // without onError, ignore exception
     }
     await oneMs();
 
-    // assert family3 hasn't been persisted
+    // assert familia3 hasn't been persisted
     expect(
-        familyRepository.offlineOperations
+        familiaRepository.offlineOperations
             .only(DataRequestType.save)
             .map((o) => o.model),
-        [family3]);
+        [familia3]);
 
     // use `reset` to forget/ignore failed to save models
-    familyRepository.offlineOperations.reset();
+    familiaRepository.offlineOperations.reset();
 
     // so it's empty again
     expect(
-        familyRepository.offlineOperations
+        familiaRepository.offlineOperations
             .only(DataRequestType.save)
             .map((o) => o.model),
         isEmpty);
   });
 
   test('delete', () async {
-    final listener = Listener<DataState<List<Family>>?>();
+    final listener = Listener<DataState<List<Familia>>?>();
     // listening to local changes enough
     final notifier =
-        familyRepository.remoteAdapter.watchAllNotifier(remote: false);
+        familiaRepository.remoteAdapter.watchAllNotifier(remote: false);
 
     dispose = notifier.addListener(listener, fireImmediately: true);
 
-    // init a family
-    final family = Family(id: '1', surname: 'Smith').init(container.read);
+    // init a familia
+    final familia = Familia(id: '1', surname: 'Smith').init(container.read);
     await oneMs();
 
     // should show up through watchAllNotifier
     verify(listener(
-      argThat(isA<DataState>().having((s) => s.model, 'model', [family])),
+      argThat(isA<DataState>().having((s) => s.model, 'model', [familia])),
     )).called(1);
 
-    // network issue deleting family
+    // network issue deleting familia
     container.read(responseProvider.notifier).state = TestResponse(text: (_) {
       throw SocketException('unreachable');
     });
 
-    // delete family and send offline exception to notifier
-    await family.delete(
+    // delete familia and send offline exception to notifier
+    await familia.delete(
       remote: true,
       onError: (e) async {
         notifier.updateWith(exception: e);
@@ -259,45 +259,45 @@ void main() async {
           .having((s) => s.exception, 'exception', isA<OfflineException>()),
     ))).called(1);
 
-    // family is remembered as failed to persist
+    // familia is remembered as failed to persist
     expect(
-        familyRepository.offlineOperations
+        familiaRepository.offlineOperations
             .only(DataRequestType.delete)
             .map((o) => o.offlineKey),
-        ['families#1']);
+        ['familia#1']);
 
     // retry
-    await familyRepository.offlineOperations.retry();
+    await familiaRepository.offlineOperations.retry();
     await oneMs();
 
     // could not be deleted upon retry
     expect(
-        familyRepository.offlineOperations
+        familiaRepository.offlineOperations
             .only(DataRequestType.delete)
             .map((o) => o.offlineKey),
-        ['families#1']);
+        ['familia#1']);
 
     // change the response to success
     container.read(responseProvider.notifier).state = TestResponse.text('');
 
     // retry
-    await familyRepository.offlineOperations.retry();
+    await familiaRepository.offlineOperations.retry();
     await oneMs();
 
     // now offline queue is empty
-    expect(familyRepository.offlineOperations, isEmpty);
+    expect(familiaRepository.offlineOperations, isEmpty);
   });
 
   test('save & delete combined', () async {
-    final listener = Listener<DataState<List<Family>>?>();
+    final listener = Listener<DataState<List<Familia>>?>();
     // listening to local changes enough
     final notifier =
-        familyRepository.remoteAdapter.watchAllNotifier(remote: false);
+        familiaRepository.remoteAdapter.watchAllNotifier(remote: false);
 
     dispose = notifier.addListener(listener, fireImmediately: true);
 
-    // setup family
-    final family = Family(id: '19', surname: 'Ko').init(container.read);
+    // setup familia
+    final familia = Familia(id: '19', surname: 'Ko').init(container.read);
     await oneMs();
 
     // network issues
@@ -306,7 +306,7 @@ void main() async {
     });
 
     // save...
-    await family.save(
+    await familia.save(
       remote: true,
       headers: {'X-Override-Name': 'Johnson'},
       // ignore: missing_return
@@ -319,7 +319,7 @@ void main() async {
     await oneMs();
 
     // ...and immediately delete
-    await family.delete(
+    await familia.delete(
       remote: true,
       onError: (e) async {
         notifier.updateWith(exception: e);
@@ -336,16 +336,16 @@ void main() async {
 
     // should see the failed save queued
     expect(
-        familyRepository.offlineOperations
+        familiaRepository.offlineOperations
             .only(DataRequestType.save)
             .map((o) => o.offlineKey)
             .toList(),
-        [keyFor(family)]);
+        [keyFor(familia)]);
 
     // clearly the local model was deleted, so the associated
     // model should be null
     expect(
-        familyRepository.offlineOperations
+        familiaRepository.offlineOperations
             .only(DataRequestType.save)
             .map((o) => o.model)
             .toList(),
@@ -353,26 +353,26 @@ void main() async {
 
     // should see the failed delete queued
     expect(
-        familyRepository.offlineOperations
+        familiaRepository.offlineOperations
             .only(DataRequestType.delete)
             .map((o) => o.offlineKey)
             .toList(),
-        ['families#19']);
+        ['familia#19']);
 
     // retry
-    await familyRepository.offlineOperations.retry();
+    await familiaRepository.offlineOperations.retry();
     await oneMs();
     // same result...
-    expect(familyRepository.offlineOperations, hasLength(2));
+    expect(familiaRepository.offlineOperations, hasLength(2));
 
     // change the response to success
     container.read(responseProvider.notifier).state = TestResponse.text('');
 
     // retry
-    await familyRepository.offlineOperations.retry();
+    await familiaRepository.offlineOperations.retry();
     await oneMs();
     // done
-    expect(familyRepository.offlineOperations, isEmpty);
+    expect(familiaRepository.offlineOperations, isEmpty);
   });
 
   test('ad-hoc request with body', () async {
@@ -382,7 +382,7 @@ void main() async {
     });
 
     // random endpoint with random headers
-    familyRepository.remoteAdapter.sendRequest(
+    familiaRepository.remoteAdapter.sendRequest(
       '/fam'.asUri,
       method: DataRequestMethod.POST,
       headers: {'X-Sats': '9389173717732'},
@@ -397,7 +397,7 @@ void main() async {
     );
     await oneMs();
     // fails to go through
-    expect(familyRepository.offlineOperations, hasLength(1));
+    expect(familiaRepository.offlineOperations, hasLength(1));
 
     // return a success response
     container.read(responseProvider.notifier).state = TestResponse(
@@ -410,10 +410,10 @@ void main() async {
     );
 
     // retry
-    await familyRepository.offlineOperations.retry();
+    await familiaRepository.offlineOperations.retry();
     await oneMs();
     // done
-    expect(familyRepository.offlineOperations, isEmpty);
+    expect(familiaRepository.offlineOperations, isEmpty);
   });
 
   test('another non-offline error should resolve the operation', () async {
@@ -421,38 +421,38 @@ void main() async {
     container.read(responseProvider.notifier).state = TestResponse(text: (_) {
       throw SocketException('unreachable');
     });
-    familyRepository.remoteAdapter.sendRequest('/fam'.asUri);
+    familiaRepository.remoteAdapter.sendRequest('/fam'.asUri);
 
     await oneMs();
     // fails to go through
-    expect(familyRepository.offlineOperations, hasLength(1));
+    expect(familiaRepository.offlineOperations, hasLength(1));
 
     // return a 404
     container.read(responseProvider.notifier).state =
         TestResponse(text: (_) => 'not found', statusCode: 404);
 
     // retry
-    await familyRepository.offlineOperations.retry();
+    await familiaRepository.offlineOperations.retry();
     await oneMs();
     // done
-    expect(familyRepository.offlineOperations, isEmpty);
+    expect(familiaRepository.offlineOperations, isEmpty);
   });
 
   test('operation equality', () {
-    final o1 = OfflineOperation<Family>(
+    final o1 = OfflineOperation<Familia>(
       requestType: DataRequestType.findAll,
-      offlineKey: 'families',
-      request: 'GET /families',
+      offlineKey: 'familia',
+      request: 'GET /familia',
       headers: {'X-Header': 'chupala'},
-      adapter: familyRemoteAdapter,
+      adapter: familiaRemoteAdapter,
     );
 
-    final o2 = OfflineOperation<Family>(
+    final o2 = OfflineOperation<Familia>(
       requestType: DataRequestType.findAll,
-      offlineKey: 'families',
-      request: 'GET /families',
+      offlineKey: 'familia',
+      request: 'GET /familia',
       headers: {'X-Header': 'chupala'},
-      adapter: familyRemoteAdapter,
+      adapter: familiaRemoteAdapter,
     );
 
     expect(o1, equals(o2));
@@ -465,20 +465,20 @@ void main() async {
       throw HandshakeException('Connection terminated during handshake');
     });
 
-    final family1 = await familyRepository.findOne('1', remote: false);
-    expect(family1, isNull);
+    final familia1 = await familiaRepository.findOne('1', remote: false);
+    expect(familia1, isNull);
 
     container.read(responseProvider.notifier).state = TestResponse.text('''
         { "id": "1", "surname": "Smith" }
       ''');
-    await familyRepository.findOne('1', remote: true);
+    await familiaRepository.findOne('1', remote: true);
 
     // cause network issue
     container.read(responseProvider.notifier).state = TestResponse(text: (_) {
       throw HandshakeException('Connection terminated during handshake');
     });
 
-    final family2 = await familyRepository.findOne('1', remote: false);
-    expect(family2, isNotNull);
+    final familia2 = await familiaRepository.findOne('1', remote: false);
+    expect(familia2, isNotNull);
   });
 }

--- a/test/repository/remote_adapter_serialization_test.dart
+++ b/test/repository/remote_adapter_serialization_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_data/flutter_data.dart';
 import 'package:test/test.dart';
 
 import '../_support/book.dart';
-import '../_support/family.dart';
+import '../_support/familia.dart';
 import '../_support/house.dart';
 import '../_support/node.dart';
 import '../_support/person.dart';
@@ -22,29 +22,29 @@ void main() async {
   });
 
   test('serialize with relationship and null attribute', () async {
-    final family = Family(
+    final familia = Familia(
       surname: 'Tao',
       persons: HasMany({Person(id: '332', name: 'Ko')}),
     );
-    expect(familyRemoteAdapter.serialize(family), {
+    expect(familiaRemoteAdapter.serialize(familia), {
       'surname': 'Tao',
       'persons': ['332']
     });
   });
 
   test('serialize embedded relationships', () async {
-    final f1 = Family(
+    final f1 = Familia(
         id: '334',
         surname: 'Zhan',
         residence: House(id: '1', address: 'Zhiwan 2').asBelongsTo,
         dogs: {Dog(id: '1', name: 'Pluto'), Dog(id: '2', name: 'Ricky')}
             .asHasMany);
 
-    final serialized = familyRemoteAdapter.serialize(f1);
+    final serialized = familiaRemoteAdapter.serialize(f1);
     expect(serialized, {
       'id': '334',
       'surname': 'Zhan',
-      // we expect persons: [] as it's default in the Family class
+      // we expect persons: [] as it's default in the Familia class
       'persons': [],
       'residence_id': '1',
       'dogs': ['1', '2']
@@ -86,41 +86,41 @@ void main() async {
 
   test('deserialize with BelongsTo id', () async {
     final p = (personRemoteAdapter.deserialize([
-      {'_id': '1', 'name': 'Na', 'age': 88, 'family_id': null}
+      {'_id': '1', 'name': 'Na', 'age': 88, 'familia_id': null}
     ])).model!;
 
-    Family(id: '1', surname: 'Kong').init(container.read);
+    Familia(id: '1', surname: 'Kong').init(container.read);
 
-    expect(p.family.key, isNull);
+    expect(p.familia.key, isNull);
 
     final p1 = (personRemoteAdapter.deserialize([
-      {'_id': '27', 'name': 'Ko', 'age': 24, 'family_id': '332'}
+      {'_id': '27', 'name': 'Ko', 'age': 24, 'familia_id': '332'}
     ])).model!;
 
-    Family(id: '332', surname: 'Tao').init(container.read);
+    Familia(id: '332', surname: 'Tao').init(container.read);
 
-    expect(p1.family.value!.id, '332');
+    expect(p1.familia.value!.id, '332');
 
     final p2 = Person(
         id: '27',
         name: 'Ko',
         age: 24,
-        family: Family(id: '332', surname: 'Tao').asBelongsTo);
+        familia: Familia(id: '332', surname: 'Tao').asBelongsTo);
 
     expect(p1, p2);
 
-    expect(p1.family.value, p2.family.value);
+    expect(p1.familia.value, p2.familia.value);
   });
 
   test('deserialize returns null if no ID is present', () async {
-    final family = (familyRemoteAdapter.deserialize([
+    final familia = (familiaRemoteAdapter.deserialize([
       {'surname': 'Ko'}
     ])).model;
-    expect(family, isNull);
+    expect(familia, isNull);
   });
 
   test('deserialize with HasMany ids (including nulls)', () async {
-    final f = (familyRemoteAdapter.deserialize([
+    final f = (familiaRemoteAdapter.deserialize([
       {
         'id': '1',
         'surname': 'Ko',
@@ -137,7 +137,7 @@ void main() async {
   });
 
   test('deserialize with embedded relationships', () async {
-    final data = familyRemoteAdapter.deserialize(
+    final data = familiaRemoteAdapter.deserialize(
       [
         {
           'id': '1',
@@ -155,7 +155,7 @@ void main() async {
     );
 
     final f1 = data.model!;
-    final f2 = Family(id: '1', surname: 'Byrde');
+    final f2 = Familia(id: '1', surname: 'Byrde');
 
     expect(f1, f2);
 
@@ -174,7 +174,7 @@ void main() async {
         {
           '_id': '1',
           'name': 'Marty',
-          'family': <String, dynamic>{
+          'familia': <String, dynamic>{
             'id': '1',
             'surname': 'Byrde',
             'residence': <String, dynamic>{
@@ -187,7 +187,7 @@ void main() async {
     );
 
     expect(data.included, [
-      Family(id: '1', surname: 'Byrde'),
+      Familia(id: '1', surname: 'Byrde'),
       House(id: '1', address: '123 Main St'),
     ]);
   });

--- a/test/repository/remote_adapter_test.dart
+++ b/test/repository/remote_adapter_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_data/flutter_data.dart';
 import 'package:test/test.dart';
 
 import '../_support/book.dart';
-import '../_support/family.dart';
+import '../_support/familia.dart';
 import '../_support/house.dart';
 import '../_support/person.dart';
 import '../_support/setup.dart';
@@ -14,29 +14,29 @@ void main() async {
   tearDown(tearDownFn);
 
   test('findAll', () async {
-    final family1 = Family(id: '1', surname: 'Smith');
-    final family2 = Family(id: '2', surname: 'Jones');
+    final familia1 = Familia(id: '1', surname: 'Smith');
+    final familia2 = Familia(id: '2', surname: 'Jones');
 
-    await familyRemoteAdapter.save(family1);
-    await familyRemoteAdapter.save(family2);
-    final families = await familyRemoteAdapter.findAll(remote: false);
+    await familiaRemoteAdapter.save(familia1);
+    await familiaRemoteAdapter.save(familia2);
+    final familia = await familiaRemoteAdapter.findAll(remote: false);
 
-    expect(families, [family1, family2]);
+    expect(familia, [familia1, familia2]);
   });
 
   test('findOne', () async {
-    final family1 = Family(id: '1', surname: 'Smith');
+    final familia1 = Familia(id: '1', surname: 'Smith');
 
-    await familyRemoteAdapter.save(family1); // possible to save without init
-    final family = await familyRemoteAdapter.findOne('1', remote: false);
-    expect(family, family1);
+    await familiaRemoteAdapter.save(familia1); // possible to save without init
+    final familia = await familiaRemoteAdapter.findOne('1', remote: false);
+    expect(familia, familia1);
   });
 
   test('findOne with includes', () async {
-    final data = familyRemoteAdapter.deserialize(json.decode('''
+    final data = familiaRemoteAdapter.deserialize(json.decode('''
       { "id": "1", "surname": "Smith", "persons": [{"_id": "1", "name": "Stan", "age": 31}] }
     ''') as Object);
-    expect(data.model, Family(id: '1', surname: 'Smith'));
+    expect(data.model, Familia(id: '1', surname: 'Smith'));
     expect(data.included, [Person(id: '1', name: 'Stan', age: 31)]);
   });
 
@@ -54,11 +54,11 @@ void main() async {
   });
 
   test('save and find', () async {
-    final family = Family(id: '32423', surname: 'Toraine');
-    await familyRemoteAdapter.save(family);
+    final familia = Familia(id: '32423', surname: 'Toraine');
+    await familiaRemoteAdapter.save(familia);
 
-    final family2 = await familyRemoteAdapter.findOne('32423', remote: false);
-    expect(family, family2);
+    final familia2 = await familiaRemoteAdapter.findOne('32423', remote: false);
+    expect(familia, familia2);
   });
 
   test('delete', () async {
@@ -128,7 +128,7 @@ void main() async {
         ]''');
 
     // remote comes back with relationships
-    final models = await familyRepository.findAll(remote: true);
+    final models = await familiaRepository.findAll(remote: true);
     expect(models.first.persons.toList(), [
       Person(id: '1', name: 'Peter', age: 10),
       Person(id: '2', name: 'John', age: 44)
@@ -137,17 +137,17 @@ void main() async {
     final originalKey = keyFor(models.first)!;
 
     // simulate app restart
-    familyRepository.dispose();
-    familyRepository =
-        await container.read(familiesRepositoryProvider).initialize(
+    familiaRepository.dispose();
+    familiaRepository =
+        await container.read(familiaRepositoryProvider).initialize(
               // ignore: invalid_use_of_protected_member
-              adapters: familyRemoteAdapter.adapters,
+              adapters: familiaRemoteAdapter.adapters,
             );
-    await familyRemoteAdapter.localAdapter
-        .save(originalKey, Family(id: '1', surname: 'Smith'), notify: false);
+    await familiaRemoteAdapter.localAdapter
+        .save(originalKey, Familia(id: '1', surname: 'Smith'), notify: false);
 
     // local storage still comes back with relationships
-    final models2 = await familyRepository.findAll(remote: false);
+    final models2 = await familiaRepository.findAll(remote: false);
     expect(models2.first.persons.toList(), [
       Person(id: '1', name: 'Peter', age: 10),
       Person(id: '2', name: 'John', age: 44)

--- a/test/repository/remote_adapter_watch_test.dart
+++ b/test/repository/remote_adapter_watch_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_data/flutter_data.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
-import '../_support/family.dart';
+import '../_support/familia.dart';
 import '../_support/house.dart';
 import '../_support/person.dart';
 import '../_support/setup.dart';
@@ -171,7 +171,7 @@ void main() async {
   });
 
   test('watchOneNotifier with alsoWatch relationships', () async {
-    final f1 = Family(
+    final f1 = Familia(
       id: '22',
       surname: 'Abagnale',
       persons: HasMany(),
@@ -179,11 +179,11 @@ void main() async {
       cottage: BelongsTo(),
     );
 
-    final notifier = familyRemoteAdapter.watchOneNotifier('22',
-        alsoWatch: (family) => [family.persons, family.residence!],
+    final notifier = familiaRemoteAdapter.watchOneNotifier('22',
+        alsoWatch: (familia) => [familia.persons, familia.residence!],
         remote: true);
 
-    final listener = Listener<DataState<Family?>?>();
+    final listener = Listener<DataState<Familia?>?>();
 
     dispose = notifier.addListener(listener, fireImmediately: true);
 
@@ -195,7 +195,7 @@ void main() async {
     await oneMs();
 
     final p1 = Person(id: '1', name: 'Frank', age: 16).init(container.read);
-    p1.family.value = f1;
+    p1.familia.value = f1;
     await oneMs();
 
     final matcher = isA<DataState>()
@@ -252,7 +252,7 @@ void main() async {
     final frank = Person(name: 'Frank', age: 30).init(container.read);
 
     final notifier = personRepository.remoteAdapter
-        .watchOneNotifier(frank, alsoWatch: (p) => [p.family]);
+        .watchOneNotifier(frank, alsoWatch: (p) => [p.familia]);
 
     final listener = Listener<DataState<Person?>?>();
     dispose = notifier.addListener(listener, fireImmediately: false);
@@ -271,14 +271,14 @@ void main() async {
     verify(listener(argThat(matcher))).called(1);
     verifyNoMoreInteractions(listener);
 
-    final family = Family(surname: 'Marquez');
-    steve.family.value = family;
+    final familia = Familia(surname: 'Marquez');
+    steve.familia.value = familia;
     await oneMs();
 
     verify(listener(argThat(matcher))).called(1);
     verifyNoMoreInteractions(listener);
 
-    Family(surname: 'Thomson').was(family);
+    Familia(surname: 'Thomson').was(familia);
     await oneMs();
 
     verify(listener(argThat(matcher))).called(1);

--- a/test/repository/repository_test.dart
+++ b/test/repository/repository_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_data/flutter_data.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
-import '../_support/family.dart';
+import '../_support/familia.dart';
 import '../_support/person.dart';
 import '../_support/pet.dart';
 import '../_support/setup.dart';
@@ -16,51 +16,52 @@ void main() async {
   tearDown(tearDownFn);
 
   test('initialization', () {
-    expect(familyRepository.isInitialized, isTrue);
+    expect(familiaRepository.isInitialized, isTrue);
   });
 
   test('findAll & clear', () async {
-    final family1 = Family(id: '1', surname: 'Smith');
-    final family2 = Family(id: '2', surname: 'Jones');
+    final familia1 = Familia(id: '1', surname: 'Smith');
+    final familia2 = Familia(id: '2', surname: 'Jones');
 
     container.read(responseProvider.notifier).state = TestResponse.text('''
         [{ "id": "1", "surname": "Smith" }, { "id": "2", "surname": "Jones" }]
       ''');
-    final families = await familyRepository.findAll();
+    final familia = await familiaRepository.findAll();
 
-    expect(families, [family1, family2]);
+    expect(familia, [familia1, familia2]);
 
-    await familyRepository.clear();
-    expect(await familyRepository.findAll(remote: false), isEmpty);
+    await familiaRepository.clear();
+    expect(await familiaRepository.findAll(remote: false), isEmpty);
   });
 
   test('findAll with and without syncLocal', () async {
-    final family1 = Family(id: '1', surname: 'Smith');
-    final family2 = Family(id: '2', surname: 'Jones');
+    final familia1 = Familia(id: '1', surname: 'Smith');
+    final familia2 = Familia(id: '2', surname: 'Jones');
 
     container.read(responseProvider.notifier).state = TestResponse.text('''
         [{ "id": "1", "surname": "Smith" }, { "id": "2", "surname": "Jones" }]
       ''');
-    final families1 = await familyRepository.findAll();
+    final familia1all = await familiaRepository.findAll();
 
-    expect(families1, [family1, family2]);
+    expect(familia1all, [familia1, familia2]);
 
     container.read(responseProvider.notifier).state = TestResponse.text('''
         [{ "id": "1", "surname": "Smith" }]
       ''');
-    final families2 = await familyRepository.findAll(syncLocal: false);
+    final familia2all = await familiaRepository.findAll(syncLocal: false);
 
-    expect(families2, [family1]);
+    expect(familia2all, [familia1]);
 
-    // since `syncLocal: false` and `family2` was present from an older call, it remains in local storage
-    expect(await familyRepository.findAll(remote: false), [family1, family2]);
+    // since `syncLocal: false` and `familia2` was present from an older call, it remains in local storage
+    expect(
+        await familiaRepository.findAll(remote: false), [familia1, familia2]);
 
-    final families3 = await familyRepository.findAll(syncLocal: true);
+    final familia3 = await familiaRepository.findAll(syncLocal: true);
 
-    expect(families3, [family1]);
+    expect(familia3, [familia1]);
 
     // using `syncLocal: true` the result is equal to the contents of local storage
-    expect(await familyRepository.findAll(remote: false), families3);
+    expect(await familiaRepository.findAll(remote: false), familia3);
   });
 
   test('findAll with error', () async {
@@ -68,10 +69,10 @@ void main() async {
       container.read(responseProvider.notifier).state = TestResponse(
           text: (_) => '''&*@~&^@^&!(@*(@#{ "id": "1", "surname": "Smith" }''',
           statusCode: 203);
-      await familyRepository.findAll();
+      await familiaRepository.findAll();
     }, throwsA(isA<DataException>()));
 
-    await familyRepository.findAll(
+    await familiaRepository.findAll(
       // ignore: missing_return
       onError: (e) {
         expect(e, isA<DataException>());
@@ -84,51 +85,51 @@ void main() async {
     container.read(responseProvider.notifier).state = TestResponse.text('''
         { "id": "1", "surname": "Smith" }
       ''');
-    final family = await familyRepository.findOne('1');
-    expect(family, Family(id: '1', surname: 'Smith'));
+    final familia = await familiaRepository.findOne('1');
+    expect(familia, Familia(id: '1', surname: 'Smith'));
 
     // and it can be found again locally
-    expect(family, await familyRepository.findOne('1', remote: false));
+    expect(familia, await familiaRepository.findOne('1', remote: false));
   });
 
   test('findOne with empty (non-null) ID works', () async {
     container.read(responseProvider.notifier).state = TestResponse.text('''
         { "id": "", "surname": "Smith" }
       ''');
-    final family = await familyRepository.findOne('');
-    expect(family, isNotNull);
+    final familia = await familiaRepository.findOne('');
+    expect(familia, isNotNull);
 
     // and it can be found again locally
-    expect(family, await familyRepository.findOne('', remote: false));
+    expect(familia, await familiaRepository.findOne('', remote: false));
   });
 
   test('findOne with changing IDs works', () async {
     container.read(responseProvider.notifier).state = TestResponse.text('''
         { "id": "new", "surname": "Smith" }
       ''');
-    final family = await familyRepository.findOne('');
-    expect(family, isNotNull);
+    final familia = await familiaRepository.findOne('');
+    expect(familia, isNotNull);
 
     // and it can be found again locally with its new ID
-    expect(family, await familyRepository.findOne('new', remote: false));
+    expect(familia, await familiaRepository.findOne('new', remote: false));
   });
 
   test('findOne with empty response', () async {
     container.read(responseProvider.notifier).state = TestResponse.text('');
-    final family = await familyRepository.findOne('1');
-    expect(family, isNull);
+    final familia = await familiaRepository.findOne('1');
+    expect(familia, isNull);
   });
 
   test('findOne with includes', () async {
     container.read(responseProvider.notifier).state = TestResponse.text('''
         { "id": "1", "surname": "Smith", "persons": [{"_id": "1", "name": "Stan", "age": 31}] }
       ''');
-    final family =
-        await familyRepository.findOne('1', params: {'include': 'people'});
-    expect(family, Family(id: '1', surname: 'Smith'));
+    final familia =
+        await familiaRepository.findOne('1', params: {'include': 'people'});
+    expect(familia, Familia(id: '1', surname: 'Smith'));
 
     // can be found again locally
-    expect(family, await familyRepository.findOne('1', remote: false));
+    expect(familia, await familiaRepository.findOne('1', remote: false));
 
     // as well as the included Person
     expect(await personRepository.findOne('1', remote: false),
@@ -144,13 +145,13 @@ void main() async {
       container.read(responseProvider.notifier).state = TestResponse(
           text: (_) => '''&*@~&^@^&!(@*(@#{ "id": "1", "surname": "Smith" }''',
           statusCode: 203);
-      await familyRepository.findOne('1');
+      await familiaRepository.findOne('1');
     }, throwsA(error203));
 
     await oneMs();
 
     // ignore: missing_return
-    await familyRepository.findOne('1', onError: (e) {
+    await familiaRepository.findOne('1', onError: (e) {
       expect(e, error203);
       return null;
     });
@@ -160,18 +161,18 @@ void main() async {
     expect(() async {
       container.read(responseProvider.notifier).state = TestResponse(
           text: (_) => '{ "error": "not found" }', statusCode: 404);
-      await familyRepository.findOne('2');
+      await familiaRepository.findOne('2');
     }, returnsNormally);
 
     // no record locally
-    expect(await familyRepository.findOne('1', remote: false), isNull);
+    expect(await familiaRepository.findOne('1', remote: false), isNull);
 
     // now throws with overriden onError
 
     expect(() async {
       container.read(responseProvider.notifier).state = TestResponse(
           text: (_) => '{ "error": "not found" }', statusCode: 404);
-      await familyRepository.findOne('2', onError: (e) => throw e);
+      await familiaRepository.findOne('2', onError: (e) => throw e);
     },
         throwsA(isA<DataException>().having(
           (e) => e.error,
@@ -180,61 +181,61 @@ void main() async {
         ).having((e) => e.statusCode, 'status code', 404)));
 
     // no record locally
-    expect(await familyRepository.findOne('1', remote: false), isNull);
+    expect(await familiaRepository.findOne('1', remote: false), isNull);
   });
 
   test('socket exception does not throw by default', () async {
     container.read(responseProvider.notifier).state =
         TestResponse(text: (_) => throw SocketException('unreachable'));
-    await familyRepository.findOne('error', onError: (e) {
+    await familiaRepository.findOne('error', onError: (e) {
       expect(e, isA<OfflineException>());
       return null;
     });
   });
 
   test('save', () async {
-    // family with id=1 does not exist
-    expect(await familyRepository.findOne('1', remote: false), isNull);
+    // familia with id=1 does not exist
+    expect(await familiaRepository.findOne('1', remote: false), isNull);
 
     // with empty response
-    final family = Family(id: '1', surname: 'Smith');
+    final familia = Familia(id: '1', surname: 'Smith');
     container.read(responseProvider.notifier).state = TestResponse.text('');
-    await familyRepository.save(family);
+    await familiaRepository.save(familia);
     // and it can be found again locally
-    expect(family, await familyRepository.findOne('1', remote: false));
+    expect(familia, await familiaRepository.findOne('1', remote: false));
 
     // with non-empty response
     container.read(responseProvider.notifier).state =
         TestResponse.text('{"id": "2", "surname": "Jones Saved"}');
-    await familyRepository.save(Family(id: '2', surname: 'Jones'));
+    await familiaRepository.save(Familia(id: '2', surname: 'Jones'));
     // and it can be found again locally
-    final family2 = await familyRepository.findOne('2', remote: false);
-    expect(family2!.surname, 'Jones Saved');
+    final familia2 = await familiaRepository.findOne('2', remote: false);
+    expect(familia2!.surname, 'Jones Saved');
   });
 
   test('save with error', () async {
-    final family = Family(id: '1', surname: 'Smith');
+    final familia = Familia(id: '1', surname: 'Smith');
     container.read(responseProvider.notifier).state =
         TestResponse.text('@**&#*#&');
 
     // overrides error handling with notifier
-    final listener = Listener<DataState<List<Family>>?>();
+    final listener = Listener<DataState<List<Familia>>?>();
     final notifier =
-        familyRepository.remoteAdapter.watchAllNotifier(remote: false);
+        familiaRepository.remoteAdapter.watchAllNotifier(remote: false);
 
     dispose = notifier.addListener(listener, fireImmediately: true);
 
     verify(listener(DataState([], isLoading: false))).called(1);
 
     // ignore: missing_return
-    await familyRepository.save(family, onError: (e) async {
+    await familiaRepository.save(familia, onError: (e) async {
       await oneMs();
       notifier.updateWith(exception: e);
       return null;
     });
     await oneMs();
 
-    verify(listener(DataState([family], isLoading: false))).called(1);
+    verify(listener(DataState([familia], isLoading: false))).called(1);
 
     verify(listener(argThat(
       isA<DataState>().having((s) {
@@ -258,12 +259,12 @@ void main() async {
   });
 
   test('watchAllNotifier', () async {
-    final listener = Listener<DataState<List<Family>>>();
+    final listener = Listener<DataState<List<Familia>>>();
 
     container.read(responseProvider.notifier).state = TestResponse.text('''
         [{ "id": "1", "surname": "Corleone" }, { "id": "2", "surname": "Soprano" }]
       ''');
-    final notifier = familyRepository.remoteAdapter.watchAllNotifier();
+    final notifier = familiaRepository.remoteAdapter.watchAllNotifier();
 
     dispose = notifier.addListener(listener, fireImmediately: true);
 
@@ -271,19 +272,19 @@ void main() async {
     await oneMs();
 
     verify(listener(DataState([
-      Family(id: '1', surname: 'Corleone'),
-      Family(id: '2', surname: 'Soprano')
+      Familia(id: '1', surname: 'Corleone'),
+      Familia(id: '2', surname: 'Soprano')
     ], isLoading: false)))
         .called(1);
     verifyNoMoreInteractions(listener);
   });
 
   test('watchAllNotifier with error', () async {
-    final listener = Listener<DataState<List<Family>>?>();
+    final listener = Listener<DataState<List<Familia>>?>();
 
     container.read(responseProvider.notifier).state =
         TestResponse(text: (_) => throw Exception('unreachable'));
-    final notifier = familyRepository.remoteAdapter.watchAllNotifier();
+    final notifier = familiaRepository.remoteAdapter.watchAllNotifier();
 
     dispose = notifier.addListener(listener, fireImmediately: true);
 
@@ -297,7 +298,7 @@ void main() async {
         .called(1);
     verifyNoMoreInteractions(listener);
 
-    // now server will successfully respond with two families
+    // now server will successfully respond with two familia
     container.read(responseProvider.notifier).state = TestResponse.text('''
         [{ "id": "1", "surname": "Corleone" }, { "id": "2", "surname": "Soprano" }]
       ''');
@@ -305,8 +306,8 @@ void main() async {
     // reload
     await notifier.reload();
 
-    final family = Family(id: '1', surname: 'Corleone');
-    final family2 = Family(id: '2', surname: 'Soprano');
+    final familia = Familia(id: '1', surname: 'Corleone');
+    final familia2 = Familia(id: '2', surname: 'Soprano');
 
     // loads again, for now exception remains
     verify(listener(argThat(isA<DataState>()
@@ -317,7 +318,8 @@ void main() async {
     await oneMs();
 
     // now responds with models, loading done, and no exception
-    verify(listener(DataState([family, family2], isLoading: false))).called(1);
+    verify(listener(DataState([familia, familia2], isLoading: false)))
+        .called(1);
     verifyNoMoreInteractions(listener);
   });
 
@@ -350,16 +352,16 @@ void main() async {
   });
 
   test('watchOneNotifier with error', () async {
-    final listener = Listener<DataState<Family?>?>();
+    final listener = Listener<DataState<Familia?>?>();
 
     container.read(responseProvider.notifier).state = TestResponse(
       text: (_) => throw Exception('whatever'),
     );
-    final notifier = familyRepository.remoteAdapter.watchOneNotifier('1');
+    final notifier = familiaRepository.remoteAdapter.watchOneNotifier('1');
 
     dispose = notifier.addListener(listener, fireImmediately: true);
 
-    verify(listener(DataState<Family?>(null, isLoading: true))).called(1);
+    verify(listener(DataState<Familia?>(null, isLoading: true))).called(1);
     await oneMs();
 
     verify(listener(argThat(isA<DataState>().having(
@@ -390,7 +392,7 @@ void main() async {
         .called(1);
     verifyNoMoreInteractions(listener);
 
-    // now server will successfully respond with a family
+    // now server will successfully respond with a familia
     container.read(responseProvider.notifier).state = TestResponse.text('''
         { "id": "1", "surname": "Corleone" }
       ''');
@@ -399,7 +401,7 @@ void main() async {
     await notifier.reload();
     await oneMs();
 
-    final family = Family(id: '1', surname: 'Corleone');
+    final familia = Familia(id: '1', surname: 'Corleone');
 
     // loads again, for now exception remains
     verify(listener(argThat(isA<DataState>()
@@ -410,24 +412,24 @@ void main() async {
     await oneMs();
 
     // now responds with model, loading done, and no exception
-    verify(listener(DataState(family, isLoading: false))).called(1);
+    verify(listener(DataState(familia, isLoading: false))).called(1);
     verifyNoMoreInteractions(listener);
   });
 
   test('watchOneNotifier with alsoWatch relationships', () async {
-    // simulate Family that exists in local storage
+    // simulate Familia that exists in local storage
     // important to keep to test `alsoWatch` assignment order
-    final family = Family(id: '22', surname: 'Paez', persons: HasMany());
-    graph.getKeyForId('families', '22', keyIfAbsent: 'families#a1a1a1');
-    await (familyRepository.remoteAdapter.localAdapter as HiveLocalAdapter)
+    final familia = Familia(id: '22', surname: 'Paez', persons: HasMany());
+    graph.getKeyForId('familia', '22', keyIfAbsent: 'familia#a1a1a1');
+    await (familiaRepository.remoteAdapter.localAdapter as HiveLocalAdapter)
         .box!
-        .put('families#a1a1a1', family);
+        .put('familia#a1a1a1', familia);
 
-    final listener = Listener<DataState<Family?>?>();
+    final listener = Listener<DataState<Familia?>?>();
 
     container.read(responseProvider.notifier).state =
         TestResponse.text('''{ "id": "22", "surname": "Paez" }''');
-    final notifier = familyRepository.remoteAdapter.watchOneNotifier(
+    final notifier = familiaRepository.remoteAdapter.watchOneNotifier(
       '22',
       alsoWatch: (f) => [f.persons],
     );
@@ -435,10 +437,10 @@ void main() async {
     dispose = notifier.addListener(listener, fireImmediately: true);
 
     // verify loading
-    verify(listener(DataState(family, isLoading: true))).called(1);
+    verify(listener(DataState(familia, isLoading: true))).called(1);
     verifyNoMoreInteractions(listener);
 
-    final f1 = await familyRepository.findOne('22', remote: false);
+    final f1 = await familiaRepository.findOne('22', remote: false);
     f1!.persons.add(Person(name: 'Martin', age: 44)); // this time without init
     await oneMs();
 
@@ -451,10 +453,10 @@ void main() async {
 
   test('watchAllNotifier updates isLoading even in an empty response',
       () async {
-    final listener = Listener<DataState<List<Family>>?>();
+    final listener = Listener<DataState<List<Familia>>?>();
 
     container.read(responseProvider.notifier).state = TestResponse.text('[]');
-    final notifier = familyRepository.remoteAdapter.watchAllNotifier();
+    final notifier = familiaRepository.remoteAdapter.watchAllNotifier();
 
     dispose = notifier.addListener(listener, fireImmediately: true);
 
@@ -472,8 +474,8 @@ void main() async {
 
     // get a new notifier and try again
 
-    final notifier2 = familyRepository.remoteAdapter.watchAllNotifier();
-    final listener2 = Listener<DataState<List<Family>>?>();
+    final notifier2 = familiaRepository.remoteAdapter.watchAllNotifier();
+    final listener2 = Listener<DataState<List<Familia>>?>();
 
     dispose?.call();
 
@@ -493,19 +495,19 @@ void main() async {
   });
 
   test('watchAllNotifier syncLocal', () async {
-    final listener = Listener<DataState<List<Family>>>();
+    final listener = Listener<DataState<List<Familia>>>();
 
     container.read(responseProvider.notifier).state = TestResponse.text(
         '''[{ "id": "22", "surname": "Paez" }, { "id": "12", "surname": "Brunez" }]''');
     final notifier =
-        familyRepository.remoteAdapter.watchAllNotifier(syncLocal: true);
+        familiaRepository.remoteAdapter.watchAllNotifier(syncLocal: true);
 
     dispose = notifier.addListener(listener, fireImmediately: true);
     await oneMs();
 
     verify(listener(DataState([
-      Family(id: '22', surname: 'Paez'),
-      Family(id: '12', surname: 'Brunez'),
+      Familia(id: '22', surname: 'Paez'),
+      Familia(id: '12', surname: 'Brunez'),
     ], isLoading: false)))
         .called(1);
 
@@ -515,50 +517,50 @@ void main() async {
     await oneMs();
 
     verify(listener(DataState([
-      Family(id: '22', surname: 'Paez'),
-      Family(id: '12', surname: 'Brunez'),
+      Familia(id: '22', surname: 'Paez'),
+      Familia(id: '12', surname: 'Brunez'),
     ], isLoading: true)))
         .called(1);
 
     verify(listener(DataState([
-      Family(id: '22', surname: 'Paez'),
+      Familia(id: '22', surname: 'Paez'),
     ], isLoading: false)))
         .called(1);
   });
 
   test('remote can return a different ID', () async {
-    Family(id: '1', surname: 'Corleone').init(container.read);
-    Family(id: '2', surname: 'Moletto').init(container.read);
+    Familia(id: '1', surname: 'Corleone').init(container.read);
+    Familia(id: '2', surname: 'Moletto').init(container.read);
 
     // returns 2, not the requested 1
     container.read(responseProvider.notifier).state =
         TestResponse.text('''{"id": "2", "surname": "Oslo"}''');
-    await familyRepository.findOne('1');
+    await familiaRepository.findOne('1');
     // (no model will show up in a watchOneNotifier('1') situation)
 
     // 1 was requested, but finally 2 was updated
-    expect(await familyRepository.findOne('2', remote: false),
-        Family(id: '2', surname: 'Oslo'));
+    expect(await familiaRepository.findOne('2', remote: false),
+        Familia(id: '2', surname: 'Oslo'));
   });
 
   test('reconcile keys under same ID', () async {
     // id=1 exists locally, has a key
-    final family1 = Family(id: '1', surname: 'Corleone').init(container.read);
+    final familia1 = Familia(id: '1', surname: 'Corleone').init(container.read);
 
-    // an id-less Family is created (obviously with new key)
-    final family2 = Family(surname: 'Moletto').init(container.read);
+    // an id-less Familia is created (obviously with new key)
+    final familia2 = Familia(surname: 'Moletto').init(container.read);
 
     // therefore these objects have different keys
-    expect(keyFor(family2), isNotNull);
-    expect(keyFor(family1), isNot(keyFor(family2)));
+    expect(keyFor(familia2), isNotNull);
+    expect(keyFor(familia1), isNot(keyFor(familia2)));
 
     // it's saved to the server
     container.read(responseProvider.notifier).state =
         TestResponse.text('''{"id": "1", "surname": "Oslo"}''');
-    await familyRepository.save(family2);
+    await familiaRepository.save(familia2);
 
     // keys are reconciled and now both keys are equal
-    expect(keyFor(family1), keyFor(family2));
+    expect(keyFor(familia1), keyFor(familia2));
   });
 
   test('custom login adapter with repo extension', () async {
@@ -606,14 +608,14 @@ void main() async {
       text: (req) => '{ "id": "1", "surname": "عمر" }',
       headers: {'content-type': 'application/json; charset=utf-8'},
     );
-    final families = await familyRepository.findOne(1);
+    final familia = await familiaRepository.findOne(1);
 
-    expect(families, Family(id: '1', surname: 'عمر'));
+    expect(familia, Familia(id: '1', surname: 'عمر'));
   });
 
   test('dispose', () {
-    familyRepository.dispose();
-    expect(familyRepository.isInitialized, isFalse);
+    familiaRepository.dispose();
+    expect(familiaRepository.isInitialized, isFalse);
   });
 }
 
@@ -628,6 +630,6 @@ Function() overridePrint(dynamic Function() testFn) => () {
     };
 
 class Bloc {
-  final Repository<Family> repo;
+  final Repository<Familia> repo;
   Bloc(this.repo);
 }

--- a/test/utils/misc_utils_test.dart
+++ b/test/utils/misc_utils_test.dart
@@ -12,7 +12,7 @@ void main() async {
     expect(
         DataHelpers.getType('Inameclasseslikeshit'), 'inameclasseslikeshits');
     expect(DataHelpers.getType('Sheep'), 'sheep');
-    expect(DataHelpers.getType('Family'), 'families');
+    expect(DataHelpers.getType('Familia'), 'familia');
     // `type` argument takes precedence
     expect(DataHelpers.getType<Person>('animal'), 'animals');
   });
@@ -37,9 +37,9 @@ void main() async {
   });
 
   test('string utils', () {
-    expect('Family'.decapitalize(), 'family');
+    expect('Familia'.decapitalize(), 'familia');
     expect(''.decapitalize(), '');
-    expect('family'.capitalize(), 'Family');
+    expect('familia'.capitalize(), 'Familia');
     expect('people'.singularize(), 'person');
     expect('zebra'.pluralize(), 'zebras');
   });


### PR DESCRIPTION
So, the problem you described in #150 is basically the same as with the `Node` class - `Family` seems to be a reserved type name in JS, which leads to the dart2js compiler renaming the type to `Family0` - which of course breaks all the tests.

I tried to work around the issue the same way as with the `Node` class, but the family class is way more integrated, and while that fixed ca. 50% of the tests, adjusting all others would have been way to much effort.

So, instead I simply renamed the `Family` type to `Familia`. It means basically the same thing, but is not a reserved type. A simple "Find - Replace" renaming was enough to fix all tests. (Note: The plural of familia seems to be familia as well)

I also reenabled the web tests, if you are okay with that, as the tests themselves seem to work fine. Also, if you ever have problems again with web tests, feel free to assign them to me, I am always happy to help!