### PR TITLE
Updates watchAllProvider and watchAllNotifier to be non-null

### DIFF
--- a/lib/src/repository/remote_adapter_watch.dart
+++ b/lib/src/repository/remote_adapter_watch.dart
@@ -2,7 +2,7 @@ part of flutter_data;
 
 mixin _RemoteAdapterWatch<T extends DataModelMixin<T>> on _RemoteAdapter<T> {
   @protected
-  DataStateNotifier<List<T>?> watchAllNotifier({
+  DataStateNotifier<List<T>> watchAllNotifier({
     bool? remote,
     Map<String, dynamic>? params,
     Map<String, String>? headers,
@@ -23,11 +23,11 @@ mixin _RemoteAdapterWatch<T extends DataModelMixin<T>> on _RemoteAdapter<T> {
     log(label, 'initializing');
 
     // closure to get latest models
-    List<T>? _getUpdatedModels() {
+    List<T> _getUpdatedModels() {
       return localAdapter.findAll();
     }
 
-    final notifier = DataStateNotifier<List<T>?>(
+    final notifier = DataStateNotifier<List<T>>(
       data: DataState(_getUpdatedModels(), isLoading: remote!),
     );
 

--- a/lib/src/repository/repository.dart
+++ b/lib/src/repository/repository.dart
@@ -256,8 +256,8 @@ class Repository<T extends DataModelMixin<T>> with _Lifecycle {
 
   // providers
 
-  AutoDisposeStateNotifierProvider<DataStateNotifier<List<T>?>,
-      DataState<List<T>?>> watchAllProvider({
+  AutoDisposeStateNotifierProvider<DataStateNotifier<List<T>>,
+      DataState<List<T>>> watchAllProvider({
     bool? remote,
     Map<String, dynamic>? params,
     Map<String, String>? headers,
@@ -279,7 +279,7 @@ class Repository<T extends DataModelMixin<T>> with _Lifecycle {
   }
 
   late final _watchAllProvider = StateNotifierProvider.autoDispose
-      .family<DataStateNotifier<List<T>?>, DataState<List<T>?>, WatchArgs<T>>(
+      .family<DataStateNotifier<List<T>>, DataState<List<T>>, WatchArgs<T>>(
           (ref, args) {
     return remoteAdapter.watchAllNotifier(
       remote: args.remote,
@@ -338,7 +338,7 @@ class Repository<T extends DataModelMixin<T>> with _Lifecycle {
 
   // notifiers
 
-  DataStateNotifier<List<T>?> watchAllNotifier(
+  DataStateNotifier<List<T>> watchAllNotifier(
       {bool? remote,
       Map<String, dynamic>? params,
       Map<String, String>? headers,

--- a/lib/src/utils/data_state.dart
+++ b/lib/src/utils/data_state.dart
@@ -124,8 +124,8 @@ class _FunctionalDataStateNotifier<T, W> extends DataStateNotifier<W> {
       if (state.hasModel) {
         W model;
 
-        if (_typesEqual<W, List<T>?>()) {
-          model = (state.model as List<T>?)?.where(test).toList() as W;
+        if (_typesEqual<W, List<T>>()) {
+          model = (state.model as List<T>).where(test).toList() as W;
         } else if (_typesEqual<W, T?>()) {
           model = test(state.model as T) ? state.model : null as W;
         } else {
@@ -190,10 +190,10 @@ class _FunctionalDataStateNotifier<T, W> extends DataStateNotifier<W> {
 }
 
 /// Functional utilities for [DataStateNotifier]
-extension DataStateNotifierListX<T> on DataStateNotifier<List<T>?> {
+extension DataStateNotifierListX<T> on DataStateNotifier<List<T>> {
   /// Filters all models of the list (if present) through [test]
-  DataStateNotifier<List<T>?> where(bool Function(T) test) {
-    return _FunctionalDataStateNotifier<T, List<T>?>(this).where(test);
+  DataStateNotifier<List<T>> where(bool Function(T) test) {
+    return _FunctionalDataStateNotifier<T, List<T>>(this).where(test);
   }
 
   /// Maps all models of the list (if present) through [convert]


### PR DESCRIPTION
In 6d3a5cfe39b1a6626f546585381121a57b8bc632 findAll was changed to not return a nullable value. This change extends that into the notifier and providers.