### PR TITLE
Fixed failing github action file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: dart-lang/setup-dart@v1.5
+      - uses: dart-lang/setup-dart@v1.5.0
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: dart pub get


### PR DESCRIPTION
Currently the build fails since there is a type in dart version. Changed it from 1.5 to 1.5.0