### PR TITLE
First assign the body to don't auto add the charset into 'Content-Type' header

### DIFF
--- a/lib/src/adapter/remote_adapter.dart
+++ b/lib/src/adapter/remote_adapter.dart
@@ -359,8 +359,8 @@ mixin _RemoteAdapter<T extends DataModelMixin<T>> on _SerializationAdapter<T> {
 
     try {
       final request = http.Request(method.toShortString(), uri & params);
-      request.headers.addAll(headers);
 
+      // First assign the body to don't auto add the charset into 'Content-Type' header
       if (body != null) {
         if (body is String) {
           request.body = body;
@@ -372,6 +372,8 @@ mixin _RemoteAdapter<T extends DataModelMixin<T>> on _SerializationAdapter<T> {
           throw ArgumentError('Invalid request body "$body".');
         }
       }
+      
+      request.headers.addAll(headers);
 
       final stream = await httpClient.send(request);
       response = await http.Response.fromStream(stream);


### PR DESCRIPTION
This is a fix for `http` dependency issue, see https://github.com/dart-lang/http/issues/1438